### PR TITLE
Integrate CodeClimate maintainability and test coverage tracking

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,27 +1,64 @@
-name: Ruby
+name: CI Build
 
 on:
   push:
-    branches:
-      - main
+    branches: [ main ]
 
   pull_request:
+     branches: [ main ]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
+    continue-on-error: true
+
     strategy:
       matrix:
-        ruby:
-          - '3.2.0'
+        ruby: ['3.0', '3.2', 'head']
+        operating-system: [ubuntu-latest]
+        # include:
+          # - ruby: 3.1
+          #   operating-system: windows-latest
+          # - ruby: jruby-head
+          #   operating-system: windows-latest
+
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.operating-system }}
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
-    - name: Run the default task
-      run: bundle exec rake
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Initialize Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run rake
+        run: bundle exec rake
+
+  coverage:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    name: Report test coverage to CodeClimate
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Initialize Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rake spec
+
+      - name: Report test coverage
+        uses: paambaati/codeclimate-action@v3.2.0
+        env:
+          CC_TEST_REPORTER_ID: 0cb028440b03ae0fc09fde63c798c23de5bcd1ba9b84bc3f816da54bd3f9b534
+        with:
+          coverageLocations: ${{github.workspace}}/coverage/lcov/*.lcov:lcov

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Semversion
 
+[![Gem Version](https://badge.fury.io/rb/semversion.svg)](https://badge.fury.io/rb/semversion)
+[![Documentation](https://img.shields.io/badge/Documentation-Latest-green)](https://rubydoc.info/gems/semversion/)
+[![Change Log](https://img.shields.io/badge/CHANGELOG-Latest-green)](https://rubydoc.info/gems/semversion/file/CHANGELOG.md)
+[![Build Status](https://github.com/main-branch/semversion/workflows/CI%20Build/badge.svg?branch=main)](https://github.com/main-branch/semversion/actions?query=workflow%3ACI%20Build)
+[![Maintainability](https://api.codeclimate.com/v1/badges/836982cfce050461dc99/maintainability)](https://codeclimate.com/github/main-branch/semversion/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/836982cfce050461dc99/test_coverage)](https://codeclimate.com/github/main-branch/semversion/test_coverage)
+
 A Gem to parse, compare, and increment versions for RubyGems.
 
 Can be used as an alternative to the [bump RubyGem](https://rubygems.org/gems/bump/).

--- a/semversion.gemspec
+++ b/semversion.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.12'
   spec.add_development_dependency 'rubocop', '~> 1.48'
   spec.add_development_dependency 'simplecov', '~> 0.22'
+  spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
   spec.add_development_dependency 'yard', '~> 0.9', '>= 0.9.28'
   spec.add_development_dependency 'yardstick', '~> 0.9'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -209,17 +209,43 @@ end
 # Setup simplecov
 
 require 'simplecov'
+require 'simplecov-lcov'
+require 'json'
 
-SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter]
+SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter, SimpleCov::Formatter::LcovFormatter]
 
 # Fail the rspec run if code coverage falls below the configured threshold
+#
+# Skip this check if the NOCOV environment variable is set to TRUE
+#
+# ```Shell
+# NOCOV=TRUE rspec
+# ```
+#
+# Example of running the tests in an infinite loop writing failures to `fail.txt`:
+#
+# ```Shell
+# while true; do
+#   NOCOV=TRUE rspec spec/process_executer/monitored_pipe_spec.rb | sed -n '/^Failures:$/, /^Finished /p' >> fail.txt
+# done
+# ````
 #
 test_coverage_threshold = 100
 SimpleCov.at_exit do
   unless RSpec.configuration.dry_run?
     SimpleCov.result.format!
-    if SimpleCov.result.covered_percent < test_coverage_threshold
+
+    if ENV['NOCOV'] != 'TRUE' && SimpleCov.result.covered_percent < test_coverage_threshold
       warn "FAIL: RSpec Test coverage fell below #{test_coverage_threshold}%"
+
+      warn "\nThe following lines were not covered by tests:\n"
+      SimpleCov.result.files.each do |source_file| # SimpleCov::SourceFile
+        source_file.missed_lines.each do |line| # SimpleCov::SourceFile::Line
+          puts "  #{source_file.project_filename}:#{line.number}"
+        end
+      end
+      warn "\n"
+
       exit 1
     end
   end


### PR DESCRIPTION
Integrate CodeClimate
* Update the CI build to report test coverage to CodeClimate
* Add CodeClimate badges to the README.md
* Update spec_helper to generate lcov test coverage report to send to CodeClimate

See the results: [![Maintainability](https://api.codeclimate.com/v1/badges/836982cfce050461dc99/maintainability)](https://codeclimate.com/github/main-branch/semversion/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/836982cfce050461dc99/test_coverage)](https://codeclimate.com/github/main-branch/semversion/test_coverage)
