### PR TITLE
Add JRuby Linux and Windows builds to CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ['3.0', '3.2', 'head']
+        ruby: ['3.0', '3.2', head, jruby-head]
         operating-system: [ubuntu-latest]
         include:
           - ruby: '3.0'

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 desc 'Run the same tasks that the CI build will run'
-task default: %w[spec rubocop yard yard:audit yard:coverage bundle:audit build]
+if RUBY_PLATFORM == 'java'
+  task default: %w[spec rubocop bundle:audit build]
+else
+  task default: %w[spec rubocop yard yard:audit yard:coverage bundle:audit build]
+end
 
 # Bundler Audit
 
@@ -28,7 +32,13 @@ CLEAN << 'Gemfile.lock'
 
 require 'rspec/core/rake_task'
 
-RSpec::Core::RakeTask.new
+RSpec::Core::RakeTask.new do
+  if RUBY_PLATFORM == 'java'
+    ENV['JAVA_OPTS'] = '-Djdk.io.File.enableADS=true'
+    ENV['JRUBY_OPTS'] = '--debug'
+    ENV['NOCOV'] = 'TRUE'
+  end
+end
 
 CLEAN << 'coverage'
 CLEAN << '.rspec_status'
@@ -47,27 +57,29 @@ end
 
 CLEAN << 'rubocop-report.json'
 
-# YARD
+unless RUBY_PLATFORM == 'java'
+  # YARD
 
-require 'yard'
-YARD::Rake::YardocTask.new do |t|
-  t.files = %w[lib/**/*.rb examples/**/*]
-end
+  require 'yard'
+  YARD::Rake::YardocTask.new do |t|
+    t.files = %w[lib/**/*.rb examples/**/*]
+  end
 
-CLEAN << '.yardoc'
-CLEAN << 'doc'
+  CLEAN << '.yardoc'
+  CLEAN << 'doc'
 
-# Yardstick
+  # Yardstick
 
-desc 'Run yardstick to show missing YARD doc elements'
-task :'yard:audit' do
-  sh "yardstick 'lib/**/*.rb'"
-end
+  desc 'Run yardstick to show missing YARD doc elements'
+  task :'yard:audit' do
+    sh "yardstick 'lib/**/*.rb'"
+  end
 
-# Yardstick coverage
+  # Yardstick coverage
 
-require 'yardstick/rake/verify'
+  require 'yardstick/rake/verify'
 
-Yardstick::Rake::Verify.new(:'yard:coverage') do |verify|
-  verify.threshold = 100
+  Yardstick::Rake::Verify.new(:'yard:coverage') do |verify|
+    verify.threshold = 100
+  end
 end

--- a/semversion.gemspec
+++ b/semversion.gemspec
@@ -35,13 +35,16 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'redcarpet', '~> 3.6'
   spec.add_development_dependency 'rspec', '~> 3.12'
   spec.add_development_dependency 'rubocop', '~> 1.48'
   spec.add_development_dependency 'simplecov', '~> 0.22'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
-  spec.add_development_dependency 'yard', '~> 0.9', '>= 0.9.28'
-  spec.add_development_dependency 'yardstick', '~> 0.9'
+
+  unless RUBY_PLATFORM == 'java'
+    spec.add_development_dependency 'redcarpet', '~> 3.6'
+    spec.add_development_dependency 'yard', '~> 0.9', '>= 0.9.28'
+    spec.add_development_dependency 'yardstick', '~> 0.9'
+  end
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -235,7 +235,7 @@ SimpleCov.at_exit do
   unless RSpec.configuration.dry_run?
     SimpleCov.result.format!
 
-    if ENV['NOCOV'] != 'TRUE' && SimpleCov.result.covered_percent < test_coverage_threshold
+    if ENV['NOCOV']&.upcase != 'TRUE' && SimpleCov.result.covered_percent < test_coverage_threshold
       warn "FAIL: RSpec Test coverage fell below #{test_coverage_threshold}%"
 
       warn "\nThe following lines were not covered by tests:\n"


### PR DESCRIPTION
Add JRuby builds to ensure that this gem works with JRuby.

This gem uses the redcarpet gem for rendering markdown in the Yard documentation. Since redcarpet does not work in JRuby, when building with JRuby do not install Yard gems (in the gemspec) or run Yard (in the Rakefile).

Code coverage in JRuby seems to be broken so do not check coverage with building with JRuby.