### PR TITLE
Update CodeClimate badges after project rename

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,6 @@ jobs:
       - name: Report test coverage
         uses: paambaati/codeclimate-action@v3.2.0
         env:
-          CC_TEST_REPORTER_ID: 0cb028440b03ae0fc09fde63c798c23de5bcd1ba9b84bc3f816da54bd3f9b534
+          CC_TEST_REPORTER_ID: f0b6388a435f5b93101b27edc5c7fb8d5db2ee6f38216f5e4eeb9e1caf686afa
         with:
           coverageLocations: ${{github.workspace}}/coverage/lcov/*.lcov:lcov

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Documentation](https://img.shields.io/badge/Documentation-Latest-green)](https://rubydoc.info/gems/semverify/)
 [![Change Log](https://img.shields.io/badge/CHANGELOG-Latest-green)](https://rubydoc.info/gems/semverify/file/CHANGELOG.md)
 [![Build Status](https://github.com/main-branch/semverify/workflows/CI%20Build/badge.svg?branch=main)](https://github.com/main-branch/semverify/actions?query=workflow%3ACI%20Build)
-[![Maintainability](https://api.codeclimate.com/v1/badges/836982cfce050461dc99/maintainability)](https://codeclimate.com/github/main-branch/semverify/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/836982cfce050461dc99/test_coverage)](https://codeclimate.com/github/main-branch/semverify/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/44a42ed085fe162e5dff/maintainability)](https://codeclimate.com/github/main-branch/semverify/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/44a42ed085fe162e5dff/test_coverage)](https://codeclimate.com/github/main-branch/semverify/test_coverage)
 
 A Gem to parse, compare, and increment versions for RubyGems.
 


### PR DESCRIPTION
After renaming the GitHub repository for #11, the CodeClimate badges needed to be re-generated.