### PR TITLE
Update Rubocop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,9 @@ AllCops:
   # your project supports:
   TargetRubyVersion: 3.0
 
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
+
 # The default max line length is 80 characters
 Layout/LineLength:
   Max: 120
@@ -20,7 +23,14 @@ Metrics/BlockLength:
     - "spec/**/*_spec.rb"
     - "*.gemspec"
 
+Metrics/ModuleLength:
+  CountAsOne: ['hash']
+
 # When writing minitest tests, it is very hard to limit test class length:
 Metrics/ClassLength:
+  CountAsOne: ['hash']
   Exclude:
     - "test/**/*_test.rb"
+
+Style/AsciiComments:
+  Enabled: false


### PR DESCRIPTION
This PR updates Rubocop configuration based on new Rubocop changes:

* The Gemspec/DevelopmentDependencies wants us to put development dependencies in the Gemfile. We want to keep them in the .gemspec
* For module length, we want hashes to only count for one line even if they span multiple lines.
* Allow unicode characters in comments.