### PR TITLE
Update README and gemspec introduction text

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,30 +7,59 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/44a42ed085fe162e5dff/maintainability)](https://codeclimate.com/github/main-branch/semverify/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/44a42ed085fe162e5dff/test_coverage)](https://codeclimate.com/github/main-branch/semverify/test_coverage)
 
-A Gem to parse, compare, and increment versions for RubyGems.
+Parse, compare, and increment RubyGem versions.
 
-Can be used as an alternative to the [bump RubyGem](https://rubygems.org/gems/bump/).
+This gem installs the `semverify` CLI tool to display and increment a gem's version
+based on SemVer rules. This tool can replace the `bump` command from the
+[bump gem](https://rubygems.org/gems/bump/) for incrementing gem version strings.
 
-* [Semverify](#semverify)
-  * [Installation](#installation)
-  * [Command Line Usage](#command-line-usage)
-  * [Library Usage](#library-usage)
-  * [Development](#development)
-  * [Contributing](#contributing)
-  * [License](#license)
+This gem also provides the `Semverify::Semver` class which knows how to parse,
+validate, and compare [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html) version
+strings.
+
+Both the CLI tool and the library code support prerelease versions and versions
+with build metadata.
+
+Example CLI commands:
+
+```bash
+# Increment the gem version
+semverify {next-major|next-minor|next-patch} [--pre [--pretype=TYPE]] [--build=METADATA] [--dryrun]
+semverify next-pre [--pretype=TYPE] [--build=METADATA] [--dryrun]
+semverify next-release [--build=METADATA] [--dryrun]
+
+# Command to display the current gem version
+semverify current
+
+# Display the gem version file
+semverify file
+
+# Validate that a version conforms to SemVer 2.0.0
+semverify validate VERSION
+
+# Get more detailed help for each command listed above
+semverify help [COMMAND]
+```
+
+* [Installation](#installation)
+* [Command Line Usage](#command-line-usage)
+* [Library Usage](#library-usage)
+* [Development](#development)
+* [Contributing](#contributing)
+* [License](#license)
 
 ## Installation
 
 Install the gem and add to the application's Gemfile by executing:
 
 ```shell
-bundle add UPDATE_WITH_YOUR_GEM_NAME_PRIOR_TO_RELEASE_TO_RUBYGEMS_ORG
+bundle add semverify
 ```
 
 If bundler is not being used to manage dependencies, install the gem by executing:
 
 ```shell
-gem install UPDATE_WITH_YOUR_GEM_NAME_PRIOR_TO_RELEASE_TO_RUBYGEMS_ORG
+gem install semverify
 ```
 
 ## Command Line Usage

--- a/lib/semverify/command_line.rb
+++ b/lib/semverify/command_line.rb
@@ -85,7 +85,7 @@ module Semverify
       --pre can be used to specify that the version should be incremented AND
       given a pre-release part. For instance:
 
-      /x5 $ semverify next-major --pre
+      $ semverify next-major --pre
 
       increments '1.2.3' to '2.0.0-pre.1'.
 
@@ -93,7 +93,7 @@ module Semverify
       --pre to specify a different pre-release type such as alpha, beta, rc, etc.
       For instance:
 
-      /x5 $ semverify next-major --pre --pre-type=alpha
+      $ semverify next-major --pre --pre-type=alpha
 
       increments '1.2.3' to '2.0.0-alpha.1'.
 
@@ -144,7 +144,7 @@ module Semverify
       --pre can be used to specify that the version should be incremented AND
       given a pre-release part. For instance:
 
-      /x5 $ semverify next-minor --pre
+      $ semverify next-minor --pre
 
       increments '1.2.3' to '2.0.0-pre.1'.
 
@@ -152,7 +152,7 @@ module Semverify
       --pre to specify a different pre-release type such as alpha, beta, rc, etc.
       For instance:
 
-      /x5 $ semverify next-patch --pre --pre-type=alpha
+      $ semverify next-patch --pre --pre-type=alpha
 
       increments '1.2.3' to '1.2.4-alpha.1'.
 
@@ -203,7 +203,7 @@ module Semverify
       --pre can be used to specify that the version should be incremented AND
       given a pre-release part. For instance:
 
-      /x5 $ semverify next-patch --pre
+      $ semverify next-patch --pre
 
       increments '1.2.3' to '1.2.4-pre.1'.
 
@@ -211,7 +211,7 @@ module Semverify
       --pre to specify a different pre-release type such as alpha, beta, rc, etc.
       For instance:
 
-      /x5 $ semverify next-patch --pre --pre-type=alpha
+      $ semverify next-patch --pre --pre-type=alpha
 
       increments '1.2.3' to '1.2.4-alpha.1'.
 
@@ -260,7 +260,7 @@ module Semverify
 
       By default, the existing pre-release type is preserved. For instance:
 
-      /x5 $ semverify next-pre
+      $ semverify next-pre
 
       Increments 1.2.3-alpha.1 to 1.2.3-alpha.2.
 
@@ -270,16 +270,16 @@ module Semverify
 
       For example, if the version starts as 1.2.3-alpha.4, then:
 
-      /x5 $ semverify current
-      /x5 1.2.3-alpha.4
-      /x5 $ semver next-pre --pre-type=beta
-      /x5 1.2.3-beta.1
-      /x5 $ semver next-pre --pre-type=beta
-      /x5 1.2.3-beta.2
-      /x5 $ semver next-pre --pre-type=rc
-      /x5 1.2.3-rc.1
-      /x5 $ semverify next-release
-      /x5 1.2.3
+      $ semverify current
+      1.2.3-alpha.4
+      $ semver next-pre --pre-type=beta
+      1.2.3-beta.1
+      $ semver next-pre --pre-type=beta
+      1.2.3-beta.2
+      $ semver next-pre --pre-type=rc
+      1.2.3-rc.1
+      $ semverify next-release
+      1.2.3
 
       The command fails if the existing pre-release type is not lexically less than or
       equal to TYPE. For example, it the current version is '1.2.3-beta.1' and the TYPE

--- a/semverify.gemspec
+++ b/semverify.gemspec
@@ -8,8 +8,43 @@ Gem::Specification.new do |spec|
   spec.authors = ['James Couball']
   spec.email = ['jcouball@yahoo.com']
 
-  spec.summary = 'A Gem to parse and compare semver versions AND bump versions for Ruby Gems'
-  spec.description = spec.summary
+  spec.summary = 'A Gem to parse and compare SemVer versions AND increment versions for Ruby Gems'
+  spec.description = <<~DESC
+    Parse, compare, and increment RubyGem versions.
+
+    This gem installs the `semverify` CLI tool to display and increment a gem's version
+    based on SemVer rules. This tool can replace the `bump` command from the
+    [bump gem](https://rubygems.org/gems/bump/) for incrementing gem version strings.
+
+    This gem also provides the `Semverify::Semver` class which knows how to parse,
+    validate, and compare [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html) version
+    strings.
+
+    Both the CLI tool and the library code support prerelease versions and versions
+    with build metadata.
+
+    Example CLI commands:
+
+    ```bash
+    # Increment the gem version
+    semverify {next-major|next-minor|next-patch} [--pre [--pretype=TYPE]] [--build=METADATA] [--dryrun]
+    semverify next-pre [--pretype=TYPE] [--build=METADATA] [--dryrun]
+    semverify next-release [--build=METADATA] [--dryrun]
+
+    # Command to display the current gem version
+    semverify current
+
+    # Display the gem version file
+    semverify file
+
+    # Validate that a version conforms to SemVer 2.0.0
+    semverify validate VERSION
+
+    # Get more detailed help for each command listed above
+    semverify help [COMMAND]
+    ```
+  DESC
+
   spec.homepage = 'http://github.com/main-branch/semverify'
   spec.license = 'MIT'
   spec.required_ruby_version = '>= 3.0.0'
@@ -32,13 +67,13 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'thor', '~> 1.2'
+  spec.add_runtime_dependency 'thor', '~> 1.3'
 
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
-  spec.add_development_dependency 'create_github_release', '~> 1.0'
-  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'create_github_release', '~> 1.3'
+  spec.add_development_dependency 'rake', '~> 13.1'
   spec.add_development_dependency 'rspec', '~> 3.12'
-  spec.add_development_dependency 'rubocop', '~> 1.48'
+  spec.add_development_dependency 'rubocop', '~> 1.59'
   spec.add_development_dependency 'simplecov', '~> 0.22'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
 


### PR DESCRIPTION
Update the README and gemspec introduction text to:

Parse, compare, and increment RubyGem versions.

This gem provides the `semverify` CLI tool to display and increment a gem's version
based on SemVer rules. This tool can replace the `bump` command from the
[bump gem](https://rubygems.org/gems/bump/) for incrementing gem version strings.

This gem also provides the `Semverify::Semver` class which knows how to parse,
validate, and compare [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html) version
strings.
