### PR TITLE
Add Gem version functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ semverify minor # 0.1.1 -> 0.2.0
 semverify major # 0.2.0 -> 1.0.0
 
 # Pre-release with default pre-release type
-semverify major --pre # 0.1.1 -> 1.0.0-pre.1
+semverify major --pre # 0.1.1 -> 1.0.0.pre.1
 
 # Pre-release with non-default pre-release type
 semverify major --pre --pre-type=alpha # 0.1.1 -> 2.0.0-alpha.1

--- a/lib/semverify.rb
+++ b/lib/semverify.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 require 'semverify/command_line'
+require 'semverify/incrementable_gem_version'
 require 'semverify/incrementable_semver'
 require 'semverify/regexp'
+require 'semverify/gem_version'
 require 'semverify/semver'
 require 'semverify/version_file'
 require 'semverify/version_file_factory'

--- a/lib/semverify/command_line.rb
+++ b/lib/semverify/command_line.rb
@@ -87,7 +87,7 @@ module Semverify
 
       $ semverify next-major --pre
 
-      increments '1.2.3' to '2.0.0-pre.1'.
+      increments '1.2.3' to '2.0.0.pre.1'.
 
       By default, the pre-release type is 'pre'. --pre-type=TYPE can be used with
       --pre to specify a different pre-release type such as alpha, beta, rc, etc.
@@ -146,7 +146,7 @@ module Semverify
 
       $ semverify next-minor --pre
 
-      increments '1.2.3' to '2.0.0-pre.1'.
+      increments '1.2.3' to '2.0.0.pre.1'.
 
       By default, the pre-release type is 'pre'. --pre-type=TYPE can be used with
       --pre to specify a different pre-release type such as alpha, beta, rc, etc.
@@ -205,7 +205,7 @@ module Semverify
 
       $ semverify next-patch --pre
 
-      increments '1.2.3' to '1.2.4-pre.1'.
+      increments '1.2.3' to '1.2.4.pre.1'.
 
       By default, the pre-release type is 'pre'. --pre-type=TYPE can be used with
       --pre to specify a different pre-release type such as alpha, beta, rc, etc.
@@ -375,7 +375,7 @@ module Semverify
     # @return [void]
     #
     def validate(version)
-      Semverify::IncrementableSemver.new(version)
+      Semverify::IncrementableGemVersion.new(version)
     rescue Semverify::Error => e
       warn e.message unless options[:quiet]
       exit 1
@@ -443,11 +443,11 @@ module Semverify
     # @param args [Hash] The arguments to pass to the method
     # @param version [String] The version to increment
     #
-    # @return [Semverify::IncrementableSemver] the incremented version
+    # @return [Semverify::IncrementableRubyVersion] the incremented version
     # @raise [Semverify::Error] if the version is not a valid IncrementableSemver version
     #
     def increment_literal_version(method, args, version)
-      Semverify::IncrementableSemver.new(version).send(method, **args)
+      Semverify::IncrementableGemVersion.new(version).send(method, **args)
     end
 
     # Increment the gem's version from the gem's version file
@@ -455,7 +455,7 @@ module Semverify
     # @param method [Symbol] The method to call on the IncrementableSemver object
     # @param args [Hash] The arguments to pass to the method
     #
-    # @return [Semverify::IncrementableSemver] the incremented version
+    # @return [Semverify::IncrementableRubyVersion] the incremented version
     # @raise [Semverify::Error] if the version is not a valid IncrementableSemver version
     #
     def increment_gem_version(method, args)

--- a/lib/semverify/gem_version.rb
+++ b/lib/semverify/gem_version.rb
@@ -1,0 +1,476 @@
+# frozen_string_literal: true
+
+require 'semverify/regexp'
+
+module Semverify
+  # Parse and compare Ruby Gem version strings
+  #
+  # This class will parse and validate a Ruby Gem version string
+  #
+  # Two GemVersion objects can be compared using the spaceship operator (<=>)
+  # according to the rules of precedence defined in
+  # [the Gem::Version class](https://rubydoc.info/gems/rubygems-update/Gem/Version).
+  #
+  # @example Basic version parsing
+  #   gem_version = Semverify::GemVersion.new('1.2.3')
+  #   gem_version.major # => '1'
+  #   gem_version.minor # => '2'
+  #   gem_version.patch # => '3'
+  #
+  # @example Parsing a version with a pre-release identifier
+  #   gem_version = Semverify::GemVersion.new('1.2.3.alpha.1')
+  #   gem_version.pre_release # => 'alpha.1'
+  #   gem_version.pre_release_identifiers # => ['alpha', '1']
+  #
+  # @example Separators are optional between pre-release identifiers
+  #   gem_version1 = Semverify::GemVersion.new('1.2.3.alpha.1')
+  #   gem_version2 = Semverify::GemVersion.new('1.2.3.alpha1')
+  #   gem_version3 = Semverify::GemVersion.new('1.2.3alpha1')
+  #
+  #   gem_version1 == gem_version2 # => true
+  #   gem_version1 == gem_version3 # => true
+  #   gem_version2 == gem_version3 # => true
+  #
+  #   gem_version1.pre_release1 # => '.alpha.1'
+  #   gem_version1.pre_release2 # => '.alpha1'
+  #   gem_version1.pre_release3 # => 'alpha1'
+  #
+  #   gem_version1.pre_release_identifiers # => ['alpha', '1']
+  #   gem_version2.pre_release_identifiers # => ['alpha', '1']
+  #   gem_version3.pre_release_identifiers # => ['alpha', '1']
+  #
+  # @example Comparing versions
+  #   gem_version1 = Semverify::GemVersion.new('1.2.3')
+  #   gem_version2 = Semverify::GemVersion.new('1.2.4')
+  #   gem_version1 <=> gem_version2 # => -1
+  #   gem_version2 <=> gem_version3 # => 1
+  #   gem_version1 <=> gem_version1 # => 0
+  #
+  # @see https://rubydoc.info/gems/rubygems-update/Gem/Version the Gem::Version class
+  #
+  # @api public
+  #
+  class GemVersion
+    include Comparable
+
+    # Create a new GemVersion object
+    #
+    # @example
+    #   version = Semverify::GemVersion.new('1.2.3.alpha.1')
+    #
+    # @param version [String] The version string to parse
+    #
+    # @raise [Semverify::Error] version is not a string or not a valid gem_version version
+    #
+    def initialize(version)
+      assert_version_must_be_a_string(version)
+      @version = version
+      parse
+      assert_valid_version
+    end
+
+    # @!attribute version [r]
+    #
+    # The complete version string
+    #
+    # @example
+    #   gem_version = Semverify::GemVersion.new('1.2.3.alpha.1+build.001')
+    #   gem_version.version #=> '1.2.3.alpha.1+build.001'
+    #
+    # @return [String]
+    #
+    # @api public
+    #
+    attr_reader :version
+
+    # @attribute major [r]
+    #
+    # The major part of the version
+    #
+    # @example
+    #   gem_version = Semverify::GemVersion.new('1.2.3.alpha.1+build.001')
+    #   gem_version.major #=> '1'
+    #
+    # @return [String]
+    #
+    # @api public
+    #
+    attr_reader :major
+
+    # @attribute minor [r]
+    #
+    # The minor part of the version
+    #
+    # @example
+    #   gem_version = Semverify::GemVersion.new('1.2.3.alpha.1+build.001')
+    #   gem_version.minor #=> '2'
+    #
+    # @return [String]
+    #
+    # @api public
+    #
+    attr_reader :minor
+
+    # @attribute patch [r]
+    #
+    # The patch part of the version
+    #
+    # @example
+    #   gem_version = Semverify::GemVersion.new('1.2.3.alpha.1+build.001')
+    #   gem_version.patch #=> '3'
+    #
+    # @return [String]
+    #
+    # @api public
+    #
+    attr_reader :patch
+
+    # @attribute pre_release [r]
+    #
+    # The pre_release part of the version
+    #
+    # Will be an empty string if the version has no pre_release part.
+    #
+    # @example
+    #   gem_version = Semverify::GemVersion.new('1.2.3.alpha.1+build.001')
+    #   gem_version.pre_release #=> 'alpha.1'
+    #
+    # @example When the version has no pre_release part
+    #   gem_version = Semverify::GemVersion.new('1.2.3')
+    #   gem_version.pre_release #=> ''
+    #
+    # @return [String]
+    #
+    # @api public
+    #
+    attr_reader :pre_release
+
+    # @attribute pre_release_identifiers [r]
+    #
+    # The pre_release identifiers of the version
+    #
+    # @example
+    #   gem_version = Semverify::GemVersion.new('1.2.3.alpha.1+build.001')
+    #   gem_version.pre_release_identifiers #=> ['alpha', '1']
+    #
+    # @example When the version has no pre_release part
+    #   gem_version = Semverify::GemVersion.new('1.2.3')
+    #   gem_version.pre_release_identifiers #=> []
+    #
+    # @return [Array<String>]
+    #
+    # @api public
+    #
+    attr_reader :pre_release_identifiers
+
+    # @attribute build_metadata [r]
+    #
+    # The build_metadata part of the version
+    #
+    # Will be an empty string if the version has no build_metadata part.
+    #
+    # @example
+    #   gem_version = Semverify::GemVersion.new('1.2.3.alpha.1+build.001')
+    #   gem_version.build_metadata #=> 'build.001'
+    #
+    # @example When the version has no build_metadata part
+    #   gem_version = Semverify::GemVersion.new('1.2.3')
+    #   gem_version.build_metadata #=> ''
+    #
+    # @return [String]
+    #
+    # @api public
+    #
+    attr_reader :build_metadata
+
+    # Compare two GemVersion objects
+    #
+    # See the [Precedence Rules](https://gem_version.org/spec/v2.0.0.html#spec-item-11)
+    # in the Semantic Versioning 2.0.0 Specification for more details.
+    #
+    # @example
+    #   gem_version1 = Semverify::GemVersion.new('1.2.3')
+    #   gem_version2 = Semverify::GemVersion.new('1.2.4')
+    #   gem_version1 <=> gem_version2 # => -1
+    #   gem_version2 <=> gem_version1 # => 1
+    #
+    # @example A GemVersion is equal to itself
+    #   gem_version1 = Semverify::GemVersion.new('1.2.3')
+    #   gem_version1 <=> gem_version1 # => 0
+    #
+    # @example A pre-release version is always older than a normal version
+    #   gem_version1 = Semverify::GemVersion.new('1.2.3.alpha.1')
+    #   gem_version2 = Semverify::GemVersion.new('1.2.3')
+    #   gem_version1 <=> gem_version2 # => -1
+    #
+    # @example Pre-releases are compared by the parts of the pre-release version
+    #   gem_version1 = Semverify::GemVersion.new('1.2.3.alpha.1')
+    #   gem_version2 = Semverify::GemVersion.new('1.2.3.alpha.2')
+    #   gem_version1 <=> gem_version2 # => -1
+    #
+    # @example Build metadata is ignored when comparing versions
+    #   gem_version1 = Semverify::GemVersion.new('1.2.3+build.100')
+    #   gem_version2 = Semverify::GemVersion.new('1.2.3+build.101')
+    #   gem_version1 <=> gem_version2 # => 0
+    #
+    # @param other [GemVersion] the other GemVersion to compare to
+    #
+    # @return [Integer] -1 if self < other, 0 if self == other, or 1 if self > other
+    #
+    # @raise [Semverify::Error] other is not a gem_version
+    #
+    def <=>(other)
+      assert_other_is_a_gem_version(other)
+
+      core_comparison = compare_core_parts(other)
+      pre_release_comparison = compare_pre_release_part(other)
+
+      return core_comparison unless core_comparison.zero? && !pre_release_comparison.zero?
+
+      return 1 if pre_release.empty?
+      return -1 if other.pre_release.empty?
+
+      pre_release_comparison
+    end
+
+    # Determine if the version string is a valid gem_version
+    #
+    # Override this method in a subclass to provide extra or custom validation.
+    #
+    # @example
+    #   Semverify::GemVersion.new('1.2.3').valid? # => true
+    #   Semverify::GemVersion.new('1.2.3.alpha.1+build.001').valid? # => true
+    #   Semverify::GemVersion.new('bogus').valid? # => raises Semverify::Error
+    #
+    # @return [Boolean] true if the version string is a valid gem_version
+    #
+    def valid?
+      # If major is set, then so is everything else
+      !major.nil?
+    end
+
+    # Two versions are equal if their version strings are equal
+    #
+    # @example
+    #   Semverify::GemVersion.new('1.2.3') == '1.2.3' # => true
+    #
+    # @param other [GemVersion] the other GemVersion to compare to
+    #
+    # @return [Boolean] true if the version strings are equal
+    #
+    def ==(other)
+      version == other.to_s
+    end
+
+    # The string representation of a GemVersion is its version string
+    #
+    # @example
+    #   Semverify::GemVersion.new('1.2.3').to_s # => '1.2.3'
+    #
+    # @return [String] the version string
+    #
+    def to_s
+      version
+    end
+
+    private
+
+    # Parse @version into its parts
+    # @return [void]
+    # @api private
+    def parse
+      return unless (match_data = version.match(Semverify::RUBYVER_REGEXP_FULL))
+
+      core_parts(match_data)
+      pre_release_part(match_data)
+      build_metadata_part(match_data)
+    end
+
+    # Compare the major, minor, and patch parts of this GemVersion to other
+    # @param other [GemVersion] the other GemVersion to compare to
+    # @return [Integer] -1 if self < other, 0 if self == other, or 1 if self > other
+    # @api private
+    def compare_core_parts(other)
+      identifiers = [major.to_i, minor.to_i, patch.to_i]
+      other_identifiers = [other.major.to_i, other.minor.to_i, other.patch.to_i]
+
+      identifiers <=> other_identifiers
+    end
+
+    # Compare two pre-release identifiers
+    #
+    # Implements the rules for precedence for comparing two pre-release identifiers
+    # from the Semantic Versioning 2.0.0 Specification.
+    #
+    # @param identifier [String, Integer] the identifier to compare
+    # @param other_identifier [String, Integer] the other identifier to compare
+    # @return [Integer] -1, 0, or 1
+    # @api private
+    def compare_identifiers(identifier, other_identifier)
+      return 1 if other_identifier.nil?
+      return -1 if identifier.is_a?(Integer) && other_identifier.is_a?(String)
+      return 1 if other_identifier.is_a?(Integer) && identifier.is_a?(String)
+
+      identifier <=> other_identifier
+    end
+
+    # Compare two pre-release version parts
+    #
+    # Implements the rules for precedence for comparing the pre-release part of
+    # one version with the pre-release part of another version from the Semantic
+    # Versioning 2.0.0 Specification.
+    #
+    # @param other [GemVersion] the other GemVersion to compare to
+    # @return [Integer] -1, 0, or 1
+    # @api private
+    def compare_pre_release_part(other)
+      pre_release_identifiers.zip(other.pre_release_identifiers).each do |field, other_field|
+        result = compare_identifiers(field&.identifier, other_field&.identifier)
+        return result unless result.zero?
+      end
+      pre_release_identifiers.size < other.pre_release_identifiers.size ? -1 : 0
+    end
+
+    # Raise a error if other is not a valid Semver
+    # @param other [GemVersion] the other to check
+    # @return [void]
+    # @raise [Semverify::Error] if other is not a valid Semver
+    # @api private
+    def assert_other_is_a_gem_version(other)
+      raise Semverify::Error, 'other must be a Semver' unless other.is_a?(GemVersion)
+    end
+
+    # Raise a error if the given version is not a string
+    # @param version [GemVersion] the version to check
+    # @return [void]
+    # @raise [Semverify::Error] if the given version is not a string
+    # @api private
+    def assert_version_must_be_a_string(version)
+      raise Semverify::Error, 'Version must be a string' unless version.is_a?(String)
+    end
+
+    # Raise a error if this version object is not a valid Semver
+    # @return [void]
+    # @raise [Semverify::Error] if other is not a valid Semver
+    # @api private
+    def assert_valid_version
+      raise Semverify::Error, "Not a valid version string: #{version}" unless valid?
+    end
+
+    # Set the major, minor, and patch parts of this Semver
+    # @param match_data [MatchData] the match data from the version string
+    # @return [void]
+    # @api private
+    def core_parts(match_data)
+      @major = match_data[:major]
+      @minor = match_data[:minor]
+      @patch = match_data[:patch]
+    end
+
+    # Set the pre-release of this Semver
+    # @param match_data [MatchData] the match data from the version string
+    # @return [void]
+    # @api private
+    def pre_release_part(match_data)
+      @pre_release = match_data[:pre_release] || ''
+      @pre_release_identifiers = tokenize_pre_release_part(@pre_release)
+    end
+
+    # Set the build_metadata of this Semver
+    # @param match_data [MatchData] the match data from the version string
+    # @return [void]
+    # @api private
+    def build_metadata_part(_match_data)
+      @build_metadata = ''
+    end
+
+    # A pre-release part of a version which consists of an optional prefix and an identifier
+    # @api private
+    class PreReleaseIdentifier
+      # @attribute prefix [r]
+      #
+      # Gem versions can optionally prefix pre-release identifiers with a period
+      #
+      # The prefix is not significant when sorting.
+      #
+      # The prefix is saved so that the pre-release part can be reconstructed
+      # exactly as it was given.
+      #
+      # @return [String] '.' if the pre-release type is prefixed with a period, otherwise ''
+      #
+      # @api private
+      #
+      attr_reader :prefix
+
+      # @attribute identifier [r]
+      #
+      # The pre-release identifier
+      #
+      # The identifier is converted to an integer if it consists only of digits.
+      # Otherwise, it is left as a string.
+      #
+      # @return [String, Integer]
+      #
+      # @api private
+      #
+      attr_reader :identifier
+
+      # Create a new PreReleaseIdentifier keeping track of the optional prefix
+      #
+      # @example
+      #   PreReleaseIdentifier.new('.pre') #=> #<PreReleaseIdentifier @identifier="pre", @prefix=".">
+      #   PreReleaseIdentifier.new('pre') #=> #<PreReleaseIdentifier @identifier="pre", @prefix="">
+      #   PreReleaseIdentifier.new('.1') #=> #<PreReleaseIdentifier @identifier=1, @prefix=".">
+      #   PreReleaseIdentifier.new('1') #=> #<PreReleaseIdentifier @identifier=1, @prefix="">
+      #
+      # @param pre_release_part_str [String] the pre-release part string to parse
+      #
+      # @return [String]
+      #
+      # @api private
+      #
+      def initialize(pre_release_part_str)
+        @prefix = pre_release_part_str.start_with?('.') ? '.' : ''
+        @identifier = determine_part(pre_release_part_str)
+      end
+
+      private
+
+      # Determine if the pre-release part is a number or a string
+      #
+      # @param pre_release_part_str [String] the pre-release part string to parse
+      #
+      # @return [String, Integer]
+      #
+      # @api private
+      #
+      def determine_part(pre_release_part_str)
+        clean_str = pre_release_part_str.delete_prefix('.')
+        clean_str.match?(/\A\d+\z/) ? clean_str.to_i : clean_str
+      end
+    end
+
+    # Parse the pre-release part of the version into an array of identifiers
+    #
+    # A pre-release version is denoted by appending one or more pre-release identifiers
+    # to the core version. The first pre-release identifier must consist of only ASCII letters.
+    # Identifiers MUST NOT be empty. Numeric identifiers MUST NOT include leading zeroes.
+    # Each identifier may be prefixed with a period '.'.
+    #
+    # @example
+    #   tokenize_pre_release_part('.alpha.1') #=> [
+    #     #<PreReleaseIdentifier @identifier="alpha", @prefix=".">,
+    #     #<PreReleaseIdentifier @identifier=1, @prefix=".">
+    #   ]
+    #
+    # @param str [String] the pre-release part string to parse (for example: '.pre.1')
+    #
+    # @return [Array<PreReleaseIdentifier>]
+    #
+    # @api private
+    #
+    def tokenize_pre_release_part(str)
+      str.scan(/\.?\d+|\.?[a-zA-Z]+/).map { |pre_release_part_str| PreReleaseIdentifier.new(pre_release_part_str) }
+    end
+  end
+end

--- a/lib/semverify/incrementable_gem_version.rb
+++ b/lib/semverify/incrementable_gem_version.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+require 'semverify/gem_version'
+
+module Semverify
+  # A Semverify::Semver with additional constraints on the pre-release part of the version
+  #
+  # A IncrementableGemVersion is valid if one of the two following conditions is met:
+  #   1. The pre-release part is empty
+  #   2. The pre-release part is composed of two dot-separated identifiers:
+  #     * the first being a String representing the pre-release type (e.g. 'alpha',
+  #       'beta', etc.). The default pre-release type is 'pre'
+  #     * the second being an Integer representing the pre-release sequence number
+  #       (starting at 1)
+  #
+  # Valid versions with pre-release parts: `1.2.3.alpha.1`, `1.2.3.beta.2`, `1.2.3.pre.3`
+  #
+  # @api public
+  #
+  class IncrementableGemVersion < GemVersion
+    # Create a new IncrementableGemVersion object
+    #
+    # @example
+    #   Semverify::Semver.new('1.2.3').valid? # => true
+    #   Semverify::Semver.new('1.2.3-alpha.1+build.001').valid? # => true
+    #   Semverify::Semver.new('1.2.3-alpha').valid? # => raise Semverify::Error
+    #   Semverify::Semver.new('1.2.3-alpha.1.2').valid? # => raise Semverify::Error
+    #   Semverify::Semver.new('1.2.3-alpha.one').valid? # => raise Semverify::Error
+    #
+    # @return [Boolean] true if the version string is a valid semver and meets the conditions above
+    #
+    def valid?
+      super && (
+        pre_release.empty? ||
+        (
+          pre_release_identifiers.size == 2 &&
+          pre_type.is_a?(String) &&
+          pre_number.is_a?(Integer)
+        )
+      )
+    end
+
+    # The default pre-release identifier
+    DEFAULT_PRE_TYPE = 'pre'
+
+    # Increment the major version
+    #
+    # @example
+    #   Semverify::IncrementableGemVersion.new('1.2.3').next_major # =>
+    #     Semverify::IncrementableGemVersion.new('2.0.0')
+    #
+    # @return [IncrementableGemVersion] a new IncrementableGemVersion object with the major version incremented
+    #
+    def next_major(pre: false, pre_type: DEFAULT_PRE_TYPE, build_metadata: nil)
+      version_string = "#{major.to_i + 1}.0.0"
+      version_string += ".#{pre_type}.1" if pre
+      build_metadata = self.build_metadata if build_metadata.nil?
+      version_string += "+#{build_metadata}" unless build_metadata.empty?
+      IncrementableGemVersion.new(version_string)
+    end
+
+    # Increment the minor version
+    #
+    # @example
+    #   Semverify::IncrementableGemVersion.new('1.2.3').next_minor # =>
+    #     Semverify::IncrementableGemVersion.new('1.3.0')
+    #
+    # @return [IncrementableGemVersion] a new IncrementableGemVersion object with the major version incremented
+    #
+    def next_minor(pre: false, pre_type: DEFAULT_PRE_TYPE, build_metadata: nil)
+      version_string = "#{major}.#{minor.to_i + 1}.0"
+      version_string += ".#{pre_type}.1" if pre
+      build_metadata = self.build_metadata if build_metadata.nil?
+      version_string += "+#{build_metadata}" unless build_metadata.empty?
+      IncrementableGemVersion.new(version_string)
+    end
+
+    # Increment the patch version
+    #
+    # @example
+    #   Semverify::IncrementableGemVersion.new('1.2.3').next_patch # =>
+    #     Semverify::IncrementableGemVersion.new('1.2.1')
+    #
+    # @return [IncrementableGemVersion] a new IncrementableGemVersion object with the patch part incremented
+    #
+    def next_patch(pre: false, pre_type: DEFAULT_PRE_TYPE, build_metadata: nil)
+      version_string = "#{major}.#{minor}.#{patch.to_i + 1}"
+      version_string += ".#{pre_type}.1" if pre
+      build_metadata = self.build_metadata if build_metadata.nil?
+      version_string += "+#{build_metadata}" unless build_metadata.empty?
+      IncrementableGemVersion.new(version_string)
+    end
+
+    # Increment the pre_release part of the version
+    #
+    # @example
+    #   Semverify::IncrementableGemVersion.new('1.2.3.pre.1').next_patch.to_s # => '1.2.3.pre.2'
+    #
+    # @return [IncrementableGemVersion] a new object with the pre_release part incremented
+    #
+    def next_pre(pre_type: nil, build_metadata: nil)
+      assert_is_a_pre_release_version
+      version_string = "#{major}.#{minor}.#{patch}"
+      version_string += next_pre_part(pre_type)
+      build_metadata ||= self.build_metadata
+      version_string += "+#{build_metadata}" unless build_metadata.empty?
+      IncrementableGemVersion.new(version_string)
+    end
+
+    # Drop the pre-release part of the version
+    #
+    # @example
+    #   Semverify::IncrementableGemVersion.new('1.2.3.pre.1').next_release.to_s # => '1.2.3'
+    #
+    # @return [IncrementableGemVersion] a new IncrementableGemVersion object with the pre_release part dropped
+    # @raise [Semverify::Error] if the version is not a pre-release version
+    #
+    def next_release(build_metadata: nil)
+      assert_is_a_pre_release_version
+      version_string = "#{major}.#{minor}.#{patch}"
+      build_metadata ||= self.build_metadata
+      version_string += "+#{build_metadata}" unless build_metadata.empty?
+      IncrementableGemVersion.new(version_string)
+    end
+
+    # The pre-release type (for example, 'alpha', 'beta', 'pre', etc.)
+    #
+    # @example
+    #   Semverify::IncrementableGemVersion.new('1.2.3.pre.1').pre_type # => 'pre'
+    #
+    # @return [String]
+    #
+    def pre_type
+      pre_release_identifiers[0].identifier
+    end
+
+    # Returns the prefix of the pre-release type
+    #
+    # Ruby Gem versions can optionally prefix the pre-release type with a period.
+    #
+    # @example
+    #   Semverify::GemVersion.new('1.2.3.pre.1').pre_type_prefix # => '-'
+    # Semver requires a hyphen prefix.
+    #
+    # @example
+    #   Semverify::IncrementableGemVersion.new('1.2.3.pre.1').pre_type # => 'pre'
+    #
+    # @return ['.', '']
+    #
+    def pre_type_prefix
+      pre_release_identifiers[0].prefix
+    end
+
+    # The pre-release sequence number
+    #
+    # The pre-release sequence number starts at 1 for each pre-release type.
+    #
+    # @example
+    #   IncrementableGemVersion.new('1.2.3.pre.1').pre_number # => 1
+    #
+    # @return [Integer]
+    #
+    def pre_number
+      pre_release_identifiers[1].identifier
+    end
+
+    # The pre-release sequence number
+    #
+    # The pre-release identifier can optionally prefix the pre-release sequence number with a period.
+    #
+    # @example
+    #   IncrementableGemVersion.new('1.2.3.pre.1').pre_number_prefix # => '.'
+    #   IncrementableGemVersion.new('1.2.3.pre1').pre_number_prefix # => ''
+    #
+    # @return [String]
+    #
+    def pre_number_prefix
+      pre_release_identifiers[1].prefix
+    end
+
+    private
+
+    # Raise an error if the version is not a pre-release version
+    #
+    # @return [void]
+    # @raise [Semverify::Error] if the version is not a pre-release version
+    # @api private
+    def assert_is_a_pre_release_version
+      return unless pre_release.empty?
+
+      raise Semverify::Error, 'Cannot increment the pre-release part of a release version'
+    end
+
+    # Raise an error if new pre-release type is less than the old pre-release type
+    #
+    # If the new pre-release type is lexically less than the old pre-release type,
+    # then raise an error because the resulting error would sort before the existing
+    # version.
+    #
+    # @return [void]
+    # @raise [Semverify::Error] if the pre-release type is not valid
+    # @api private
+    def assert_pre_type_is_valid(pre_type)
+      return if self.pre_type <= pre_type
+
+      message = 'Cannot increment the pre-release identifier ' \
+                "from '#{self.pre_type}' to '#{pre_type}' " \
+                "because '#{self.pre_type}' is lexically less than '#{pre_type}'"
+
+      raise Semverify::Error, message
+    end
+
+    # Return the next pre-release part
+    # @param pre_type [String, nil] the given pre-release type or nil to use the existing pre-release type
+    # @return [String]
+    # @api private
+    def next_pre_part(pre_type)
+      pre_type ||= self.pre_type
+      assert_pre_type_is_valid(pre_type)
+      next_pre_number = self.pre_type == pre_type ? (pre_number + 1) : 1
+      "#{pre_type_prefix}#{pre_type}#{pre_number_prefix}#{next_pre_number}"
+    end
+  end
+end

--- a/lib/semverify/regexp.rb
+++ b/lib/semverify/regexp.rb
@@ -1,6 +1,30 @@
 # frozen_string_literal: true
 
 module Semverify
+  # Match a gem_version within a string
+  RUBYVER_REGEXP = /
+    (?<gem_version>
+      (?<major>0|[1-9]\d*)
+      \.
+      (?<minor>0|[1-9]\d*)
+      \.
+      (?<patch>0|[1-9]\d*)
+      (?<pre_release>
+        (?:
+          \.?
+          [a-z]+
+          (?:
+            \.?
+            (?:[a-z]+|\d+)
+          )*
+        )?
+      )
+    )
+  /x
+
+  # Match a gem_version to the full string
+  RUBYVER_REGEXP_FULL = /\A#{RUBYVER_REGEXP.source}\z/x
+
   # Match a semver within a string
   SEMVER_REGEXP = /
     (?<semver>

--- a/lib/semverify/version_file.rb
+++ b/lib/semverify/version_file.rb
@@ -20,13 +20,13 @@ module Semverify
     # @param version [String] the version
     # @param content_after [String] the content after the version
     #
-    # @raise [Semverify::Error] if the version is not an IncrementableSemver
+    # @raise [Semverify::Error] if the version is not an IncrementableGemVersion
     #
     # @api private
     #
     def initialize(path, content_before, version, content_after)
-      raise Semverify::Error, 'version must be an IncrementableSemver' unless
-        version.is_a?(Semverify::IncrementableSemver)
+      raise Semverify::Error, 'version must be an IncrementableGemVersion' unless
+        version.is_a?(Semverify::IncrementableGemVersion)
 
       @path = path
       @content_before = content_before
@@ -61,11 +61,11 @@ module Semverify
     # The version from the version file
     #
     # @example
-    #   version = Semverify::IncrementableSemver.new('1.2.3')
+    #   version = Semverify::IncrementableGemVersion.new('1.2.3')
     #   version_file = Semverify::VersionFile.new('lib/semverify/version.rb', 'VERSION = "', version, '"')
     #   version_file.version.to_s # => '1.2.3'
-    # @return [Semverify::IncrementableSemver]
-    # @raise [Semverify::Error] if the version is not an IncrementableSemver
+    # @return [Semverify::IncrementableGemVersion]
+    # @raise [Semverify::Error] if the version is not an IncrementableGemVersion
     # @api public
     attr_reader :version
 
@@ -82,17 +82,17 @@ module Semverify
 
     # Update the version in the version file
     #
-    # @param new_version [Semverify::IncrementableSemver] the new version
+    # @param new_version [Semverify::IncrementableGemVersion] the new version
     # @example
     #   version_file = Semverify::VersionFile.new('lib/semverify/version.rb', 'VERSION = "', '1.2.3', '"')
     #   version_file.version = '1.2.4'
     # @return [Void]
-    # @raise [Semverify::Error] if new_version is not an IncrementableSemver
+    # @raise [Semverify::Error] if new_version is not an IncrementableGemVersion
     # @api public
     #
     def version=(new_version)
-      raise Semverify::Error, 'new_version must be an IncrementableSemver' unless
-        new_version.is_a?(Semverify::IncrementableSemver)
+      raise Semverify::Error, 'new_version must be an IncrementableGemVersion' unless
+        new_version.is_a?(Semverify::IncrementableGemVersion)
 
       @version = version
       File.write(path, content_before + new_version.to_s + content_after)

--- a/lib/semverify/version_file_sources/base.rb
+++ b/lib/semverify/version_file_sources/base.rb
@@ -19,7 +19,7 @@ module Semverify
       def self.find
         Dir[glob].filter_map do |path|
           if (match = File.read(path).match(content_regexp))
-            version = Semverify::IncrementableSemver.new(match[:version])
+            version = Semverify::IncrementableGemVersion.new(match[:version])
             Semverify::VersionFile.new(path, match[:content_before], version, match[:content_after])
           end
         end.first

--- a/lib/semverify/version_file_sources/gemspec.rb
+++ b/lib/semverify/version_file_sources/gemspec.rb
@@ -16,7 +16,7 @@ module Semverify
             .*
             \.version\s*=\s*(?<quote>['"])
           )
-          (?<version>#{Semverify::SEMVER_REGEXP.source})
+          (?<version>#{Semverify::RUBYVER_REGEXP.source})
           (?<content_after>\k<quote>.*)
         \z
       /xm

--- a/lib/semverify/version_file_sources/version.rb
+++ b/lib/semverify/version_file_sources/version.rb
@@ -13,7 +13,7 @@ module Semverify
       VERSION_REGEXP = /
         \A
           (?<content_before>\s*)
-          (?<version>#{Semverify::SEMVER_REGEXP.source})
+          (?<version>#{Semverify::RUBYVER_REGEXP.source})
           (?<content_after>\s*)
         \z
       /x

--- a/lib/semverify/version_file_sources/version_rb.rb
+++ b/lib/semverify/version_file_sources/version_rb.rb
@@ -16,7 +16,7 @@ module Semverify
             .*
             VERSION\s*=\s*(?<quote>['"])
           )
-          (?<version>#{Semverify::SEMVER_REGEXP.source})
+          (?<version>#{Semverify::RUBYVER_REGEXP.source})
           (?<content_after>\k<quote>.*)
         \z
       /xm

--- a/spec/semversion/command_line_current_spec.rb
+++ b/spec/semversion/command_line_current_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Semverify::CommandLine do
     subject { described_class.start(['current', *args]) }
 
     let(:args) { [] }
-    let(:expected_version) { '1.2.3-pre.1+build.999' }
+    let(:expected_version) { '1.2.3.pre.1' }
 
     context 'when a version file could not be found' do
       it 'should exit with exitstatus 1 and an error to stderr' do

--- a/spec/semversion/command_line_file_spec.rb
+++ b/spec/semversion/command_line_file_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Semverify::CommandLine do
     end
 
     context 'with a valid version file' do
-      let(:expected_version) { '1.2.3-pre.1+build.999' }
+      let(:expected_version) { '1.2.3.pre.1' }
 
       before do
         File.write('VERSION', expected_version)

--- a/spec/semversion/command_line_next_major_spec.rb
+++ b/spec/semversion/command_line_next_major_spec.rb
@@ -4,6 +4,6 @@ require 'tmpdir'
 
 RSpec.describe Semverify::CommandLine do
   context '#next_major' do
-    it_behaves_like 'Core Version Incrementer', :major, '1.2.3', '2.0.0'
+    it_behaves_like 'Gem Core Version Incrementer', :major, '1.2.3', '2.0.0'
   end
 end

--- a/spec/semversion/command_line_next_minor_spec.rb
+++ b/spec/semversion/command_line_next_minor_spec.rb
@@ -4,6 +4,6 @@ require 'tmpdir'
 
 RSpec.describe Semverify::CommandLine do
   context '#next_minor' do
-    it_behaves_like 'Core Version Incrementer', :minor, '1.2.3', '1.3.0'
+    it_behaves_like 'Gem Core Version Incrementer', :minor, '1.2.3', '1.3.0'
   end
 end

--- a/spec/semversion/command_line_next_patch_spec.rb
+++ b/spec/semversion/command_line_next_patch_spec.rb
@@ -4,6 +4,6 @@ require 'tmpdir'
 
 RSpec.describe Semverify::CommandLine do
   context '#next_patch' do
-    it_behaves_like 'Core Version Incrementer', :patch, '1.2.3', '1.2.4'
+    it_behaves_like 'Gem Core Version Incrementer', :patch, '1.2.3', '1.2.4'
   end
 end

--- a/spec/semversion/command_line_next_pre_spec.rb
+++ b/spec/semversion/command_line_next_pre_spec.rb
@@ -3,7 +3,7 @@
 require 'tmpdir'
 
 RSpec.describe Semverify::CommandLine do
-  from_version = '1.2.3-beta.4'
+  from_version = '1.2.3.beta.4'
 
   context '#next_pre' do
     subject { described_class.start(['next-pre', *args]) }
@@ -40,38 +40,38 @@ RSpec.describe Semverify::CommandLine do
       end
     end
 
-    context "when given VERSION is #{from_version}+AMD64" do
-      let(:version) { "#{from_version}+AMD64" }
+    # context "when given VERSION is #{from_version}+AMD64" do
+    #   let(:version) { "#{from_version}+AMD64" }
 
-      context 'when --build is not given' do
-        let(:args) { [version] }
-        it 'should output 1.2.3-beta.5+AMD64 (preserve the build metadata)' do
-          expect { subject }.to output("1.2.3-beta.5+AMD64\n").to_stdout
-        end
-      end
+    #   context 'when --build is not given' do
+    #     let(:args) { [version] }
+    #     it 'should output 1.2.3-beta.5+AMD64 (preserve the build metadata)' do
+    #       expect { subject }.to output("1.2.3-beta.5+AMD64\n").to_stdout
+    #     end
+    #   end
 
-      context 'when --build="" is given' do
-        let(:args) { [version, '--build='] }
-        it 'should output 1.2.3-beta.5 (clear the build metadata)' do
-          expect { subject }.to output("1.2.3-beta.5\n").to_stdout
-        end
-      end
+    #   context 'when --build="" is given' do
+    #     let(:args) { [version, '--build='] }
+    #     it 'should output 1.2.3-beta.5 (clear the build metadata)' do
+    #       expect { subject }.to output("1.2.3-beta.5\n").to_stdout
+    #     end
+    #   end
 
-      context 'when --build=368 is given' do
-        let(:args) { [version, '--build=386'] }
-        it 'should output 1.2.3-beta.5+386 (replace the build metadata)' do
-          expect { subject }.to output("1.2.3-beta.5+386\n").to_stdout
-        end
-      end
-    end
+    #   context 'when --build=368 is given' do
+    #     let(:args) { [version, '--build=386'] }
+    #     it 'should output 1.2.3-beta.5+386 (replace the build metadata)' do
+    #       expect { subject }.to output("1.2.3-beta.5+386\n").to_stdout
+    #     end
+    #   end
+    # end
 
     context "when given VERSION is #{from_version}" do
       let(:version) { from_version }
       let(:args) { [version] }
 
       context 'when not other args are given' do
-        it "should output '1.2.3-beta.5' (clear the pre-release)" do
-          expect { subject }.to output("1.2.3-beta.5\n").to_stdout
+        it "should output '1.2.3.beta.5' (clear the pre-release)" do
+          expect { subject }.to output("1.2.3.beta.5\n").to_stdout
         end
       end
 
@@ -86,22 +86,22 @@ RSpec.describe Semverify::CommandLine do
       context 'when --pre-type=beta is given' do
         let(:args) { [version, '--pre-type=beta'] }
 
-        it "should output '1.2.3-beta.5' (clear the pre-release)" do
-          expect { subject }.to output("1.2.3-beta.5\n").to_stdout
+        it "should output '1.2.3.beta.5' (clear the pre-release)" do
+          expect { subject }.to output("1.2.3.beta.5\n").to_stdout
         end
       end
 
       context 'when --pre-type=rc is given' do
         let(:args) { [version, '--pre-type=rc'] }
 
-        it "should output '1.2.3-rc.1' (clear the pre-release)" do
-          expect { subject }.to output("1.2.3-rc.1\n").to_stdout
+        it "should output '1.2.3.rc.1' (clear the pre-release)" do
+          expect { subject }.to output("1.2.3.rc.1\n").to_stdout
         end
       end
 
       context 'when --dry-run is given' do
-        it "should output '1.2.3-beta.5' (clear the pre-release)" do
-          expect { subject }.to output("1.2.3-beta.5\n").to_stdout
+        it "should output '1.2.3.beta.5' (clear the pre-release)" do
+          expect { subject }.to output("1.2.3.beta.5\n").to_stdout
         end
       end
 
@@ -126,9 +126,9 @@ RSpec.describe Semverify::CommandLine do
       context "when the version file contains the version #{from_version}" do
         before { File.write('VERSION', from_version) }
 
-        it 'should output 1.2.3-beta.5 and update the version in the version file to 1.2.3-beta.5' do
-          expect { subject }.to output("1.2.3-beta.5\n").to_stdout
-          expect(File.read('VERSION')).to eq('1.2.3-beta.5')
+        it 'should output 1.2.3.beta.5 and update the version in the version file to 1.2.3.beta.5' do
+          expect { subject }.to output("1.2.3.beta.5\n").to_stdout
+          expect(File.read('VERSION')).to eq('1.2.3.beta.5')
         end
       end
 
@@ -137,8 +137,8 @@ RSpec.describe Semverify::CommandLine do
 
         before { File.write('VERSION', from_version) }
 
-        it 'should output 1.2.3-beta.5 and leave the version in the version file alone' do
-          expect { subject }.to output("1.2.3-beta.5\n").to_stdout
+        it 'should output 1.2.3.beta.5 and leave the version in the version file alone' do
+          expect { subject }.to output("1.2.3.beta.5\n").to_stdout
           expect(File.read('VERSION')).to eq(from_version)
         end
       end

--- a/spec/semversion/command_line_next_release_spec.rb
+++ b/spec/semversion/command_line_next_release_spec.rb
@@ -3,7 +3,7 @@
 require 'tmpdir'
 
 RSpec.describe Semverify::CommandLine do
-  from_version = '1.2.3-beta.4'
+  from_version = '1.2.3.beta.4'
 
   context '#next_release' do
     subject { described_class.start(['next-release', *args]) }
@@ -40,30 +40,30 @@ RSpec.describe Semverify::CommandLine do
       end
     end
 
-    context "when given VERSION is #{from_version}+AMD64" do
-      let(:version) { "#{from_version}+AMD64" }
+    # context "when given VERSION is #{from_version}+AMD64" do
+    #   let(:version) { "#{from_version}+AMD64" }
 
-      context 'when --build is not given' do
-        let(:args) { [version] }
-        it 'should output 1.2.3+AMD64 (preserve the build metadata)' do
-          expect { subject }.to output("1.2.3+AMD64\n").to_stdout
-        end
-      end
+    #   context 'when --build is not given' do
+    #     let(:args) { [version] }
+    #     it 'should output 1.2.3+AMD64 (preserve the build metadata)' do
+    #       expect { subject }.to output("1.2.3+AMD64\n").to_stdout
+    #     end
+    #   end
 
-      context 'when --build="" is given' do
-        let(:args) { [version, '--build='] }
-        it 'should output 1.2.3 (clear the build metadata)' do
-          expect { subject }.to output("1.2.3\n").to_stdout
-        end
-      end
+    #   context 'when --build="" is given' do
+    #     let(:args) { [version, '--build='] }
+    #     it 'should output 1.2.3 (clear the build metadata)' do
+    #       expect { subject }.to output("1.2.3\n").to_stdout
+    #     end
+    #   end
 
-      context 'when --build=368 is given' do
-        let(:args) { [version, '--build=386'] }
-        it 'should output 1.2.3+386 (replace the build metadata)' do
-          expect { subject }.to output("1.2.3+386\n").to_stdout
-        end
-      end
-    end
+    #   context 'when --build=368 is given' do
+    #     let(:args) { [version, '--build=386'] }
+    #     it 'should output 1.2.3+386 (replace the build metadata)' do
+    #       expect { subject }.to output("1.2.3+386\n").to_stdout
+    #     end
+    #   end
+    # end
 
     context "when given VERSION is #{from_version}" do
       let(:version) { from_version }

--- a/spec/semversion/command_line_validate_spec.rb
+++ b/spec/semversion/command_line_validate_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Semverify::CommandLine do
     subject { described_class.start(['validate', *args]) }
 
     let(:args) { [] }
-    let(:expected_version) { '1.2.3-pre.1+build.999' }
+    let(:expected_version) { '1.2.3.pre.1' }
 
     context 'when VERSION is not given' do
       it 'should exit with exitstatus 1 and an error to stderr' do

--- a/spec/semversion/gem_version_spec.rb
+++ b/spec/semversion/gem_version_spec.rb
@@ -1,0 +1,225 @@
+# frozen_string_literal: true
+
+RSpec.describe Semverify::GemVersion do
+  describe '#initialize' do
+    subject { described_class.new(version) }
+
+    context 'when version is not a string' do
+      let(:version) { 1 }
+      it 'should raise an Semverify::Error' do
+        expect { subject }.to raise_error(Semverify::Error)
+      end
+    end
+
+    context 'with an invalid version' do
+      let(:version) { 'asdf' }
+      it 'should raise an Semverify::Error' do
+        expect { subject }.to raise_error(Semverify::Error)
+      end
+    end
+
+    context 'with a partial version' do
+      let(:version) { '1.2' }
+      it 'should raise an Semverify::Error' do
+        expect { subject }.to raise_error(Semverify::Error)
+      end
+    end
+
+    context 'with too many version numbers' do
+      let(:version) { '1.2.3.4' }
+      it 'should raise an Semverify::Error' do
+        expect { subject }.to raise_error(Semverify::Error)
+      end
+    end
+
+    context 'with version 1.2.3' do
+      let(:version) { '1.2.3' }
+      it do
+        is_expected.to(
+          have_attributes(
+            major: '1',
+            minor: '2',
+            patch: '3',
+            pre_release: '',
+            build_metadata: ''
+          )
+        )
+      end
+    end
+
+    context 'with a version that includes a pre-release part' do
+      let(:version) { '1.2.3.pre.1' }
+      it do
+        is_expected.to(
+          have_attributes(
+            major: '1',
+            minor: '2',
+            patch: '3',
+            pre_release: '.pre.1',
+            build_metadata: ''
+          )
+        )
+      end
+    end
+
+    context 'with a version that includes a build metadata part' do
+      let(:version) { '1.2.3.pre.1+build.001' }
+      it 'should raise an Semverify::Error' do
+        expect { subject }.to raise_error(Semverify::Error)
+      end
+    end
+  end
+
+  describe '<=>' do
+    let(:semver_version) { described_class.new(version) }
+    let(:other_semver_version) { described_class.new(other_version) }
+
+    context 'with simple versions consisting of only major, minor, and patch parts' do
+      context 'with two versions that differ only by the major part (1.0.0 < 2.0.0)' do
+        let(:version) { '1.0.0' }
+        let(:other_version) { '2.0.0' }
+        it 'should sort the lesser version first' do
+          expect(semver_version <=> other_semver_version).to eq(-1)
+          expect(other_semver_version <=> semver_version).to eq(1)
+        end
+      end
+      context 'with two versions that differ only by the minor part (0.1.0 < 0.2.0)' do
+        let(:version) { '0.1.0' }
+        let(:other_version) { '0.2.0' }
+        it 'should sort the lesser version first' do
+          expect(semver_version <=> other_semver_version).to eq(-1)
+          expect(other_semver_version <=> semver_version).to eq(1)
+        end
+      end
+
+      context 'with two versions that differ only by the patch part (0.0.1 < 0.0.1)' do
+        let(:version) { '0.0.1' }
+        let(:other_version) { '0.0.2' }
+        it 'should sort the lesser version first' do
+          expect(semver_version <=> other_semver_version).to eq(-1)
+          expect(other_semver_version <=> semver_version).to eq(1)
+        end
+      end
+
+      context 'version parts should be compared numerically (9.0.0 < 10.0.0)' do
+        let(:version) { '9.0.0' }
+        let(:other_version) { '10.0.0' }
+        it 'should sort the lesser version first' do
+          expect(semver_version <=> other_semver_version).to eq(-1)
+          expect(other_semver_version <=> semver_version).to eq(1)
+        end
+      end
+
+      context 'with two versions whose parts are all equal (1.0.0 == 1.0.0)' do
+        let(:version) { '1.0.0' }
+        let(:other_version) { '1.0.0' }
+        it 'should indicate they are equal' do
+          expect(semver_version <=> other_semver_version).to eq(0)
+        end
+      end
+    end
+
+    context 'with pre-release versions' do
+      context 'when pre-release part is not separated by periods' do
+        let(:version) { '1.0.0pre1' }
+        let(:other_version) { '1.0.0.pre.1' }
+        it 'should sort by the major, minor, and patch parts only' do
+          expect(semver_version <=> other_semver_version).to eq(0)
+          expect(other_semver_version <=> semver_version).to eq(0)
+        end
+      end
+
+      context 'with versions where major, minor, or patch parts differ (1.0.0 < 2.0.0.pre.1)' do
+        let(:version) { '1.0.0' }
+        let(:other_version) { '2.0.0.pre.1' }
+        it 'should sort by the major, minor, and patch parts only' do
+          expect(semver_version <=> other_semver_version).to eq(-1)
+          expect(other_semver_version <=> semver_version).to eq(1)
+        end
+      end
+
+      context 'with versions that are equal except one has a pre-release part (1.0.0.pre.1 < 1.0.0)' do
+        let(:version) { '1.0.0.pre.1' }
+        let(:other_version) { '1.0.0' }
+        it 'should sort the version with the pre-relase part before the other version' do
+          expect(semver_version <=> other_semver_version).to eq(-1)
+          expect(other_semver_version <=> semver_version).to eq(1)
+        end
+      end
+
+      context 'with versions that both have pre-release parts' do
+        context 'when the pre-release parts are the same (1.0.0.pre.1 = 1.0.0.pre.1)' do
+          let(:version) { '1.0.0.pre.1' }
+          let(:other_version) { '1.0.0.pre.1' }
+          it 'should indicate the versions are equal' do
+            expect(semver_version <=> other_semver_version).to eq(0)
+          end
+        end
+
+        context 'when the pre-release parts differ in number of identifiers (1.0.0-alpha < 1.0.0-alpha.1)' do
+          let(:version) { '1.0.0.alpha' }
+          let(:other_version) { '1.0.0.alpha.1' }
+          it 'should sort the version with the fewer identifiers before the other version' do
+            expect(semver_version <=> other_semver_version).to eq(-1)
+            expect(other_semver_version <=> semver_version).to eq(1)
+          end
+        end
+
+        context 'when the pre-release parts both have numerical identifiers (1.0.0-alpha.9 < 1.0.0-alpha.10)' do
+          let(:version) { '1.0.0.alpha.9' }
+          let(:other_version) { '1.0.0.alpha.10' }
+          it 'should sort those identifiers numerically (i.e. 9 < 10)' do
+            expect(semver_version <=> other_semver_version).to eq(-1)
+            expect(other_semver_version <=> semver_version).to eq(1)
+          end
+        end
+
+        context 'when the pre-release parts have non-numerical identifiers (1.0.0-alpha < 1.0.0-beta)' do
+          let(:version) { '1.0.0.alpha' }
+          let(:other_version) { '1.0.0.beta' }
+          it 'short sort those identifiers lexicographically (i.e. "alpha" < "beta")' do
+            expect(semver_version <=> other_semver_version).to eq(-1)
+            expect(other_semver_version <=> semver_version).to eq(1)
+          end
+        end
+
+        context 'when pre-release identifiers differ in type of identifiers (1.0.0-alpha.999 < 1.0.0-alpha.a)' do
+          let(:version) { '1.0.0.alpha.999' }
+          let(:other_version) { '1.0.0.alpha.a' }
+          it 'should sort the numeric identifier before the non-numeric identifier (i.e. 999 < "a")' do
+            expect(semver_version <=> other_semver_version).to eq(-1)
+            expect(other_semver_version <=> semver_version).to eq(1)
+          end
+        end
+      end
+    end
+  end
+
+  describe '#to_s' do
+    subject { described_class.new(version).to_s }
+    let(:version) { '1.0.0.pre.1' }
+
+    it 'should return the version string' do
+      expect(subject).to eq(version)
+    end
+  end
+
+  describe '#==' do
+    subject { described_class.new(version) == described_class.new(other_version) }
+    context "with version '1.2.3.alpha.1'" do
+      let(:version) { '1.2.3.alpha.1' }
+      context "with other version '1.2.3.alpha.1'" do
+        let(:other_version) { '1.2.3.alpha.1' }
+        it { is_expected.to eq(true) }
+      end
+      context "with other version '1.2.3.alpha'" do
+        let(:other_version) { '1.2.3.alpha' }
+        it { is_expected.to eq(false) }
+      end
+      context "with other version '1.2.3'" do
+        let(:other_version) { '1.2.3' }
+        it { is_expected.to eq(false) }
+      end
+    end
+  end
+end

--- a/spec/semversion/incrementable_gem_version_spec.rb
+++ b/spec/semversion/incrementable_gem_version_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Semverify::IncrementableSemver do
+RSpec.describe Semverify::IncrementableGemVersion do
   let(:version_object) { described_class.new(version) }
 
   describe '#initialize' do
@@ -12,20 +12,20 @@ RSpec.describe Semverify::IncrementableSemver do
     end
 
     context 'with a version that has a pre-release part with one identifier' do
-      let(:version) { '1.2.3-alpha' }
+      let(:version) { '1.2.3.alpha' }
       it 'is expected to raise an Semverify::Error' do
         expect { subject }.to raise_error(Semverify::Error)
       end
     end
 
     context 'with a version that has a pre-release part with two identifiers' do
-      let(:version) { '1.2.3-alpha.1' }
+      let(:version) { '1.2.3.alpha.1' }
       context 'when the first identifier is a String and the second is an Integer' do
         it { is_expected.to be_a(described_class) }
       end
 
       context 'when either the first identifier is NOT a string or the second is NOT an Integer' do
-        let(:version) { '1.2.3-alpha.one' }
+        let(:version) { '1.2.3.alpha.one' }
         it 'is expected to raise an Semverify::Error' do
           expect { subject }.to raise_error(Semverify::Error)
         end
@@ -33,7 +33,7 @@ RSpec.describe Semverify::IncrementableSemver do
     end
 
     context 'when the version has a pre-release part with more than two identifiers' do
-      let(:version) { '1.2.3-alpha.1.2' }
+      let(:version) { '1.2.3.alpha.1.2' }
       it 'is expected to raise an Semverify::Error' do
         expect { subject }.to raise_error(Semverify::Error)
       end
@@ -55,7 +55,7 @@ RSpec.describe Semverify::IncrementableSemver do
       context 'when arg pre: true is given' do
         let(:args) { { pre: true } }
         let(:version) { '1.2.3' }
-        let(:expected_version) { described_class.new('2.0.0-pre.1') }
+        let(:expected_version) { described_class.new('2.0.0.pre.1') }
         it 'should increment the major part and set the pre-release part to "pre.1"' do
           expect(subject).to eq(expected_version)
         end
@@ -64,36 +64,8 @@ RSpec.describe Semverify::IncrementableSemver do
       context "when args pre: true, pre_suffix: 'alpha' are given" do
         let(:args) { { pre: true, pre_type: 'alpha' } }
         let(:version) { '1.2.3' }
-        let(:expected_version) { described_class.new('2.0.0-alpha.1') }
+        let(:expected_version) { described_class.new('2.0.0.alpha.1') }
         it 'should increment the major part and set the pre-release part to "alpha.1"' do
-          expect(subject).to eq(expected_version)
-        end
-      end
-    end
-
-    context 'when the version has a build metadata part' do
-      context 'when build_metadata is not given' do
-        let(:version) { '1.2.3+ARM64' }
-        let(:expected_version) { described_class.new('2.0.0+ARM64') }
-        it 'should increment the major part and preserve the build metadata part' do
-          expect(subject).to eq(expected_version)
-        end
-      end
-
-      context 'when non-blank build_metadata is given' do
-        let(:args) { { build_metadata: 'new' } }
-        let(:version) { '1.2.3+old' }
-        let(:expected_version) { described_class.new('2.0.0+new') }
-        it 'should increment the major part and replace the build metadata part with given build_metadata' do
-          expect(subject).to eq(expected_version)
-        end
-      end
-
-      context 'when blank build_metadata is given' do
-        let(:args) { { build_metadata: '' } }
-        let(:version) { '1.2.3+ARM64' }
-        let(:expected_version) { described_class.new('2.0.0') }
-        it 'should increment the major part and remove the build metadata part' do
           expect(subject).to eq(expected_version)
         end
       end
@@ -101,7 +73,7 @@ RSpec.describe Semverify::IncrementableSemver do
 
     context 'when the version has a pre-release part' do
       context 'with out any args' do
-        let(:version) { '1.2.3-alpha.1' }
+        let(:version) { '1.2.3.alpha.1' }
         let(:expected_version) { described_class.new('2.0.0') }
         it 'should increment the major part and clear the pre-release part' do
           expect(subject).to eq(expected_version)
@@ -110,8 +82,8 @@ RSpec.describe Semverify::IncrementableSemver do
 
       context 'when the arg pre: true is given' do
         let(:args) { { pre: true } }
-        let(:version) { '1.2.3-pre.3' }
-        let(:expected_version) { described_class.new('2.0.0-pre.1') }
+        let(:version) { '1.2.3.pre.3' }
+        let(:expected_version) { described_class.new('2.0.0.pre.1') }
         it "should increment the major part and set pre-release part to 'pre.1'" do
           expect(subject).to eq(expected_version)
         end
@@ -119,8 +91,8 @@ RSpec.describe Semverify::IncrementableSemver do
 
       context 'when the args pre: true, pre_type: "alpha" are given' do
         let(:args) { { pre: true, pre_type: 'alpha' } }
-        let(:version) { '1.2.3-pre.3' }
-        let(:expected_version) { described_class.new('2.0.0-alpha.1') }
+        let(:version) { '1.2.3.pre.3' }
+        let(:expected_version) { described_class.new('2.0.0.alpha.1') }
         it "should increment the major part and set pre-release part to 'alpha.1'" do
           expect(subject).to eq(expected_version)
         end
@@ -143,7 +115,7 @@ RSpec.describe Semverify::IncrementableSemver do
       context 'when arg pre: true is given' do
         let(:args) { { pre: true } }
         let(:version) { '1.2.3' }
-        let(:expected_version) { described_class.new('1.3.0-pre.1') }
+        let(:expected_version) { described_class.new('1.3.0.pre.1') }
         it 'should incrementthe minor part and set the pre-release part to "pre.1"' do
           expect(subject).to eq(expected_version)
         end
@@ -152,36 +124,8 @@ RSpec.describe Semverify::IncrementableSemver do
       context "when args pre: true, pre_suffix: 'alpha' are given" do
         let(:args) { { pre: true, pre_type: 'alpha' } }
         let(:version) { '1.2.3' }
-        let(:expected_version) { described_class.new('1.3.0-alpha.1') }
+        let(:expected_version) { described_class.new('1.3.0.alpha.1') }
         it 'should increment the minor part and set the pre-release part to "alpha.1"' do
-          expect(subject).to eq(expected_version)
-        end
-      end
-    end
-
-    context 'when the version has a build metadata part' do
-      context 'when build_metadata is not given' do
-        let(:version) { '1.2.3+ARM64' }
-        let(:expected_version) { described_class.new('1.3.0+ARM64') }
-        it 'should increment the minor part and preserve the build metadata part' do
-          expect(subject).to eq(expected_version)
-        end
-      end
-
-      context 'when non-blank build_metadata is given' do
-        let(:args) { { build_metadata: 'new' } }
-        let(:version) { '1.2.3+old' }
-        let(:expected_version) { described_class.new('1.3.0+new') }
-        it 'should increment the minor part and replace the build metadata part with given build_metadata' do
-          expect(subject).to eq(expected_version)
-        end
-      end
-
-      context 'when blank build_metadata is given' do
-        let(:args) { { build_metadata: '' } }
-        let(:version) { '1.2.3+ARM64' }
-        let(:expected_version) { described_class.new('1.3.0') }
-        it 'should increment the minor part and remove the build metadata part' do
           expect(subject).to eq(expected_version)
         end
       end
@@ -189,7 +133,7 @@ RSpec.describe Semverify::IncrementableSemver do
 
     context 'when the version has a pre-release part' do
       context 'with out any args' do
-        let(:version) { '1.2.3-alpha.1' }
+        let(:version) { '1.2.3.alpha.1' }
         let(:expected_version) { described_class.new('1.3.0') }
         it 'should increment the minor part and clear the pre-release part' do
           expect(subject).to eq(expected_version)
@@ -198,8 +142,8 @@ RSpec.describe Semverify::IncrementableSemver do
 
       context 'when the arg pre: true is given' do
         let(:args) { { pre: true } }
-        let(:version) { '1.2.3-pre.3' }
-        let(:expected_version) { described_class.new('1.3.0-pre.1') }
+        let(:version) { '1.2.3.pre.3' }
+        let(:expected_version) { described_class.new('1.3.0.pre.1') }
         it "should increment the minor part and set pre-release part to 'pre.1'" do
           expect(subject).to eq(expected_version)
         end
@@ -207,8 +151,8 @@ RSpec.describe Semverify::IncrementableSemver do
 
       context 'when the args pre: true, pre_type: "alpha" are given' do
         let(:args) { { pre: true, pre_type: 'alpha' } }
-        let(:version) { '1.2.3-pre.3' }
-        let(:expected_version) { described_class.new('1.3.0-alpha.1') }
+        let(:version) { '1.2.3.pre.3' }
+        let(:expected_version) { described_class.new('1.3.0.alpha.1') }
         it "should increment the minor part and set pre-release part to 'alpha.1'" do
           expect(subject).to eq(expected_version)
         end
@@ -228,11 +172,11 @@ RSpec.describe Semverify::IncrementableSemver do
     end
 
     context "when the version has a pre_release part 'beta.1'" do
-      let(:version) { '1.2.3-beta.1' }
+      let(:version) { '1.2.3.beta.1' }
 
       context 'when no args are given' do
         it 'should increment the pre-release part to "beta.2"' do
-          expect(subject).to eq(described_class.new('1.2.3-beta.2'))
+          expect(subject).to eq(described_class.new('1.2.3.beta.2'))
         end
       end
 
@@ -248,45 +192,14 @@ RSpec.describe Semverify::IncrementableSemver do
         context "when the arg { pre_type: 'beta' } is given" do
           let(:args) { { pre_type: 'beta' } }
           it "should increment the pre-release part to 'beta.2'" do
-            expect(subject).to eq(described_class.new('1.2.3-beta.2'))
+            expect(subject).to eq(described_class.new('1.2.3.beta.2'))
           end
         end
 
         context "when the arg { pre_type: 'rc' } is given" do
           let(:args) { { pre_type: 'rc' } }
           it "should increment the pre-release part to 'rc.1'" do
-            expect(subject).to eq(described_class.new('1.2.3-rc.1'))
-          end
-        end
-
-        context 'when the version has a build metadata part' do
-          let(:version) { '1.2.3-beta.1+AMD64' }
-
-          context 'when build_metadata arg is not given' do
-            it 'should increment the pre_release part and preserve the build_metadata part' do
-              expect(subject).to eq(described_class.new('1.2.3-beta.2+AMD64'))
-            end
-          end
-
-          context 'when the arg { build_metadata: nil } is given' do
-            let(:args) { { build_metadata: nil } }
-            it 'should increment the pre_release part and remove the build_metadata part' do
-              expect(subject).to eq(described_class.new('1.2.3-beta.2+AMD64'))
-            end
-          end
-
-          context "when the arg { build_metadata: '' } is given" do
-            let(:args) { { build_metadata: '' } }
-            it 'should increment the pre_release part and remove the build_metadata part' do
-              expect(subject).to eq(described_class.new('1.2.3-beta.2'))
-            end
-          end
-
-          context "when the arg { build_metadata: '386' } is given" do
-            let(:args) { { build_metadata: '386' } }
-            it 'should increment the pre_release part and replace the build_metadata part' do
-              expect(subject).to eq(described_class.new('1.2.3-beta.2+386'))
-            end
+            expect(subject).to eq(described_class.new('1.2.3.rc.1'))
           end
         end
       end
@@ -308,7 +221,7 @@ RSpec.describe Semverify::IncrementableSemver do
       context 'when arg pre: true is given' do
         let(:args) { { pre: true } }
         let(:version) { '1.2.3' }
-        let(:expected_version) { described_class.new('1.2.4-pre.1') }
+        let(:expected_version) { described_class.new('1.2.4.pre.1') }
         it 'should increment the patch part and set the pre-release part to "pre.1"' do
           expect(subject).to eq(expected_version)
         end
@@ -317,36 +230,8 @@ RSpec.describe Semverify::IncrementableSemver do
       context "when args pre: true, pre_suffix: 'alpha' are given" do
         let(:args) { { pre: true, pre_type: 'alpha' } }
         let(:version) { '1.2.3' }
-        let(:expected_version) { described_class.new('1.2.4-alpha.1') }
+        let(:expected_version) { described_class.new('1.2.4.alpha.1') }
         it 'should increment the patch part and set the pre-release part to "alpha.1"' do
-          expect(subject).to eq(expected_version)
-        end
-      end
-    end
-
-    context 'when the version has a build metadata part' do
-      context 'when build_metadata is not given' do
-        let(:version) { '1.2.3+ARM64' }
-        let(:expected_version) { described_class.new('1.2.4+ARM64') }
-        it 'should increment the patch part and preserve the build metadata part' do
-          expect(subject).to eq(expected_version)
-        end
-      end
-
-      context 'when non-blank build_metadata is given' do
-        let(:args) { { build_metadata: 'new' } }
-        let(:version) { '1.2.3+old' }
-        let(:expected_version) { described_class.new('1.2.4+new') }
-        it 'should increment the patch part and replace the build metadata part with given build_metadata' do
-          expect(subject).to eq(expected_version)
-        end
-      end
-
-      context 'when blank build_metadata is given' do
-        let(:args) { { build_metadata: '' } }
-        let(:version) { '1.2.3+ARM64' }
-        let(:expected_version) { described_class.new('1.2.4') }
-        it 'should increment the patch part and remove the build metadata part' do
           expect(subject).to eq(expected_version)
         end
       end
@@ -354,7 +239,7 @@ RSpec.describe Semverify::IncrementableSemver do
 
     context 'when the version has a pre-release part' do
       context 'with out any args' do
-        let(:version) { '1.2.3-alpha.1' }
+        let(:version) { '1.2.3.alpha.1' }
         let(:expected_version) { described_class.new('1.2.4') }
         it 'should increment the patch part and clear the pre-release part' do
           expect(subject).to eq(expected_version)
@@ -363,8 +248,8 @@ RSpec.describe Semverify::IncrementableSemver do
 
       context 'when the arg pre: true is given' do
         let(:args) { { pre: true } }
-        let(:version) { '1.2.3-pre.3' }
-        let(:expected_version) { described_class.new('1.2.4-pre.1') }
+        let(:version) { '1.2.3.pre.3' }
+        let(:expected_version) { described_class.new('1.2.4.pre.1') }
         it "should increment the patch part and set pre-release part to 'pre.1'" do
           expect(subject).to eq(expected_version)
         end
@@ -372,8 +257,8 @@ RSpec.describe Semverify::IncrementableSemver do
 
       context 'when the args pre: true, pre_type: "alpha" are given' do
         let(:args) { { pre: true, pre_type: 'alpha' } }
-        let(:version) { '1.2.3-pre.3' }
-        let(:expected_version) { described_class.new('1.2.4-alpha.1') }
+        let(:version) { '1.2.3.pre.3' }
+        let(:expected_version) { described_class.new('1.2.4.alpha.1') }
         it "should increment the patch part and set pre-release part to 'alpha.1'" do
           expect(subject).to eq(expected_version)
         end
@@ -387,48 +272,15 @@ RSpec.describe Semverify::IncrementableSemver do
 
     context 'when the version does not have a pre_release part' do
       let(:version) { '1.2.3' }
-      it 'should raise a Seversion::Error because you can not release a non-pre-release version' do
+      it 'should raise a Seversion::Error because you can not release a non.pre-release version' do
         expect { subject }.to raise_error(Semverify::Error)
       end
     end
 
     context 'when the version is a pre-release version' do
-      let(:version) { '1.2.3-beta.1' }
-      it 'should return a non-pre-release version' do
+      let(:version) { '1.2.3.beta.1' }
+      it 'should return a non.pre-release version' do
         expect(subject).to eq(described_class.new('1.2.3'))
-      end
-
-      context 'when the version does not include a build_metadata part' do
-        context 'when the arg build_metadata: "AMD64" is given' do
-          let(:args) { { build_metadata: 'AMD64' } }
-          it "should return a non-pre-release version with the build_metadata set to 'AMD64'" do
-            expect(subject).to eq(described_class.new('1.2.3+AMD64'))
-          end
-        end
-      end
-
-      context "when the version includes a build_metadata part '123456'" do
-        let(:version) { '1.2.3-beta.1+123456' }
-
-        context 'when no args are given' do
-          it 'should return a non-pre-release version with the build_metadata preserved' do
-            expect(subject).to eq(described_class.new('1.2.3+123456'))
-          end
-        end
-
-        context 'when the arg build_metadata: "AMD64" is given' do
-          let(:args) { { build_metadata: 'AMD64' } }
-          it "should return a non-pre-release version with the build_metadata set to 'AMD64'" do
-            expect(subject).to eq(described_class.new('1.2.3+AMD64'))
-          end
-        end
-
-        context "when the arg build_metadata: '' is given" do
-          let(:args) { { build_metadata: '' } }
-          it 'should return a non-pre-release version with the build_metadata removed' do
-            expect(subject).to eq(described_class.new('1.2.3'))
-          end
-        end
       end
     end
   end

--- a/spec/semversion/version_file_factory_spec.rb
+++ b/spec/semversion/version_file_factory_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Semverify::VersionFileFactory do
       around do |example|
         Dir.mktmpdir do |dir|
           Dir.chdir(dir) do
-            File.write('VERSION', '1.2.3-pre.1+build.999')
+            File.write('VERSION', '1.2.3.pre.1')
             example.run
           end
         end
@@ -37,7 +37,7 @@ RSpec.describe Semverify::VersionFileFactory do
           have_attributes(
             path: 'VERSION',
             content_before: '',
-            version: Semverify::IncrementableSemver.new('1.2.3-pre.1+build.999'),
+            version: Semverify::IncrementableGemVersion.new('1.2.3.pre.1'),
             content_after: ''
           )
         )
@@ -66,7 +66,7 @@ RSpec.describe Semverify::VersionFileFactory do
           have_attributes(
             path: 'lib/semverify/version.rb',
             content_before: "module Semverify\n  VERSION = '",
-            version: Semverify::IncrementableSemver.new('0.1.0'),
+            version: Semverify::IncrementableGemVersion.new('0.1.0'),
             content_after: "'\nend\n"
           )
         )
@@ -79,7 +79,7 @@ RSpec.describe Semverify::VersionFileFactory do
           Dir.chdir(dir) do
             File.write('semverify.gemspec', <<~GEMSPEC)
               Gem::Specification.new do |spec|
-                spec.version = '2.0.0-pre.1'
+                spec.version = '2.0.0.pre.1'
               end
             GEMSPEC
             example.run
@@ -94,7 +94,7 @@ RSpec.describe Semverify::VersionFileFactory do
           have_attributes(
             path: 'semverify.gemspec',
             content_before: "Gem::Specification.new do |spec|\n  spec.version = '",
-            version: Semverify::IncrementableSemver.new('2.0.0-pre.1'),
+            version: Semverify::IncrementableGemVersion.new('2.0.0.pre.1'),
             content_after: "'\nend\n"
           )
         )

--- a/spec/semversion/version_file_spec.rb
+++ b/spec/semversion/version_file_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Semverify::VersionFile do
       VERSION = '
   CONTENT_BEFORE
 
-  let(:version) { Semverify::IncrementableSemver.new('1.2.3') }
+  let(:version) { Semverify::IncrementableGemVersion.new('1.2.3') }
 
   let(:content_after) { <<~CONTENT_AFTER }
     '
@@ -34,7 +34,7 @@ RSpec.describe Semverify::VersionFile do
   end
 
   describe '#version=' do
-    let(:new_version) { Semverify::IncrementableSemver.new('9.9.9') }
+    let(:new_version) { Semverify::IncrementableGemVersion.new('9.9.9') }
 
     let(:original_content) { <<~ORIGINAL_CONTENT }
       # frozen_string_literal: true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,178 @@ RSpec::Matchers.define :exit_with do |expected_status, expected_stderr|
   supports_block_expectations
 end
 
-RSpec.shared_examples 'Core Version Incrementer' do |part, from_version, to_version|
+# RSpec.shared_examples 'Semver Core Version Incrementer' do |part, from_version, to_version|
+#   command = "next-#{part}"
+#   subject { described_class.start([command, *args]) }
+
+#   let(:args) { [] }
+
+#   around do |example|
+#     Dir.mktmpdir do |dir|
+#       Dir.chdir(dir) do
+#         example.run
+#       end
+#     end
+#   end
+
+#   context 'when given an invalid VERSION' do
+#     let(:version) { 'invalid' }
+#     let(:args) { [version] }
+#     it 'should exit with exitstatus 1 and an error to stderr' do
+#       expect { subject }.to exit_with(1, "Not a valid version string: invalid\n")
+#     end
+#   end
+
+#   context 'when given extra args' do
+#     let(:args) { [from_version, 'extra'] }
+#     it 'should exit with exitstatus 1, report the error, and show usage' do
+#       expect { subject }.to exit_with(1, /^ERROR: .*\nUsage: /)
+#     end
+#   end
+
+#   context 'when given an invalid option' do
+#     let(:args) { [from_version, '--invalid'] }
+#     it 'should exit with exitstatus 1, report the error, and show usage' do
+#       expect { subject }.to exit_with(1, /^ERROR: .*\nUsage: /)
+#     end
+#   end
+
+#   context "when given VERSION is #{from_version}+AMD64" do
+#     let(:version) { "#{from_version}+AMD64" }
+
+#     context 'when --build is not given' do
+#       let(:args) { [version] }
+#       it "should output #{to_version}+AMD64 (preserve the build metadata)" do
+#         expect { subject }.to output("#{to_version}+AMD64\n").to_stdout
+#       end
+#     end
+
+#     context 'when --build="" is given' do
+#       let(:args) { [version, '--build='] }
+#       it "should output #{to_version} (clear the build metadata)" do
+#         expect { subject }.to output("#{to_version}\n").to_stdout
+#       end
+#     end
+
+#     context 'when --build=368 is given' do
+#       let(:args) { [version, '--build=386'] }
+#       it "should output #{to_version}+386 (replace the build metadata)" do
+#         expect { subject }.to output("#{to_version}+386\n").to_stdout
+#       end
+#     end
+#   end
+
+#   context "when given VERSION is #{from_version}-beta.4" do
+#     let(:version) { "#{from_version}-beta.4" }
+
+#     context 'when --pre is not given' do
+#       let(:args) { [version] }
+#       it "should output #{to_version} (clear the pre-release)" do
+#         expect { subject }.to output("#{to_version}\n").to_stdout
+#       end
+#     end
+
+#     context 'when --pre is given' do
+#       let(:args) { [version, '--pre'] }
+#       it "should output #{to_version}-pre.1 (use the default pre-release type 'pre')" do
+#         expect { subject }.to output("#{to_version}-pre.1\n").to_stdout
+#       end
+#     end
+
+#     context 'when --pre and --pre-type=alpha are given' do
+#       let(:args) { [version, '--pre', '--pre-type=alpha'] }
+#       it "should output #{to_version}-alpha.1 (use the given pre-release type)" do
+#         expect { subject }.to output("#{to_version}-alpha.1\n").to_stdout
+#       end
+#     end
+#   end
+
+#   context "when given VERSION is #{from_version}" do
+#     let(:version) { from_version }
+#     let(:args) { [version] }
+
+#     it "should output #{to_version}" do
+#       expect { subject }.to output("#{to_version}\n").to_stdout
+#     end
+
+#     context 'when given the --pre option' do
+#       let(:args) { [version, '--pre'] }
+
+#       it "should output #{to_version}-pre.1 (using the default pre-release type 'pre')" do
+#         expect { subject }.to output("#{to_version}-pre.1\n").to_stdout
+#       end
+#     end
+
+#     context 'when given the --pre and --pre-type=alpha options' do
+#       let(:args) { [version, '--pre', '--pre-type=alpha'] }
+
+#       it "should output #{to_version}-alpha.1 (using the pre-release type given)" do
+#         expect { subject }.to output("#{to_version}-alpha.1\n").to_stdout
+#       end
+#     end
+
+#     context 'when given the --build=AMD64 option' do
+#       let(:args) { [version, '--build=AMD64'] }
+
+#       it "should output #{to_version}+AMD64" do
+#         expect { subject }.to output("#{to_version}+AMD64\n").to_stdout
+#       end
+#     end
+
+#     context 'when given the --dry-run option' do
+#       let(:args) { [version, '--dry-run'] }
+
+#       # --dry-run is implied when VERSION is given, so no difference in the
+#       # functionality
+#       #
+#       it "should output #{to_version}" do
+#         expect { subject }.to output("#{to_version}\n").to_stdout
+#       end
+#     end
+
+#     context 'when given the --quiet option' do
+#       let(:args) { [version, '--quiet'] }
+
+#       # --dry-run is implied when VERSION is given, so no difference in the
+#       # functionality
+#       #
+#       it "should return #{from_version}" do
+#         expect { subject }.to output('').to_stdout
+#       end
+#     end
+#   end
+
+#   context 'when VERSION is not given' do
+#     let(:args) { [] }
+#     context 'when a version file could not be found' do
+#       it 'should exit with exitstatus 1 and report the error' do
+#         expect { subject }.to exit_with(1, "version file not found or is not valid\n")
+#       end
+#     end
+
+#     context "when the version file contains the version #{from_version}" do
+#       before { File.write('VERSION', from_version) }
+
+#       it "should output #{to_version} and update the version in the version file to #{to_version}" do
+#         expect { subject }.to output("#{to_version}\n").to_stdout
+#         expect(File.read('VERSION')).to eq(to_version)
+#       end
+#     end
+
+#     context "when given --dry-run and the version file contains the version #{from_version}" do
+#       let(:args) { ['--dry-run'] }
+
+#       before { File.write('VERSION', from_version) }
+
+#       it "should output #{to_version} and leave the version in the version file alone" do
+#         expect { subject }.to output("#{to_version}\n").to_stdout
+#         expect(File.read('VERSION')).to eq(from_version)
+#       end
+#     end
+#   end
+# end
+
+RSpec.shared_examples 'Gem Core Version Incrementer' do |part, from_version, to_version|
   command = "next-#{part}"
   subject { described_class.start([command, *args]) }
 
@@ -71,33 +242,8 @@ RSpec.shared_examples 'Core Version Incrementer' do |part, from_version, to_vers
     end
   end
 
-  context "when given VERSION is #{from_version}+AMD64" do
-    let(:version) { "#{from_version}+AMD64" }
-
-    context 'when --build is not given' do
-      let(:args) { [version] }
-      it "should output #{to_version}+AMD64 (preserve the build metadata)" do
-        expect { subject }.to output("#{to_version}+AMD64\n").to_stdout
-      end
-    end
-
-    context 'when --build="" is given' do
-      let(:args) { [version, '--build='] }
-      it "should output #{to_version} (clear the build metadata)" do
-        expect { subject }.to output("#{to_version}\n").to_stdout
-      end
-    end
-
-    context 'when --build=368 is given' do
-      let(:args) { [version, '--build=386'] }
-      it "should output #{to_version}+386 (replace the build metadata)" do
-        expect { subject }.to output("#{to_version}+386\n").to_stdout
-      end
-    end
-  end
-
-  context "when given VERSION is #{from_version}-beta.4" do
-    let(:version) { "#{from_version}-beta.4" }
+  context "when given VERSION is #{from_version}.beta.4" do
+    let(:version) { "#{from_version}.beta.4" }
 
     context 'when --pre is not given' do
       let(:args) { [version] }
@@ -108,15 +254,15 @@ RSpec.shared_examples 'Core Version Incrementer' do |part, from_version, to_vers
 
     context 'when --pre is given' do
       let(:args) { [version, '--pre'] }
-      it "should output #{to_version}-pre.1 (use the default pre-release type 'pre')" do
-        expect { subject }.to output("#{to_version}-pre.1\n").to_stdout
+      it "should output #{to_version}.pre.1 (use the default pre-release type 'pre')" do
+        expect { subject }.to output("#{to_version}.pre.1\n").to_stdout
       end
     end
 
     context 'when --pre and --pre-type=alpha are given' do
       let(:args) { [version, '--pre', '--pre-type=alpha'] }
-      it "should output #{to_version}-alpha.1 (use the given pre-release type)" do
-        expect { subject }.to output("#{to_version}-alpha.1\n").to_stdout
+      it "should output #{to_version}.alpha.1 (use the given pre-release type)" do
+        expect { subject }.to output("#{to_version}.alpha.1\n").to_stdout
       end
     end
   end
@@ -132,24 +278,16 @@ RSpec.shared_examples 'Core Version Incrementer' do |part, from_version, to_vers
     context 'when given the --pre option' do
       let(:args) { [version, '--pre'] }
 
-      it "should output #{to_version}-pre.1 (using the default pre-release type 'pre')" do
-        expect { subject }.to output("#{to_version}-pre.1\n").to_stdout
+      it "should output #{to_version}.pre.1 (using the default pre-release type 'pre')" do
+        expect { subject }.to output("#{to_version}.pre.1\n").to_stdout
       end
     end
 
     context 'when given the --pre and --pre-type=alpha options' do
       let(:args) { [version, '--pre', '--pre-type=alpha'] }
 
-      it "should output #{to_version}-alpha.1 (using the pre-release type given)" do
-        expect { subject }.to output("#{to_version}-alpha.1\n").to_stdout
-      end
-    end
-
-    context 'when given the --build=AMD64 option' do
-      let(:args) { [version, '--build=AMD64'] }
-
-      it "should output #{to_version}+AMD64" do
-        expect { subject }.to output("#{to_version}+AMD64\n").to_stdout
+      it "should output #{to_version}.alpha.1 (using the pre-release type given)" do
+        expect { subject }.to output("#{to_version}.alpha.1\n").to_stdout
       end
     end
 


### PR DESCRIPTION
Gem versions have slightly different rules than Semantic Version when incrementing them. This PR add support for Gem versions and changes the semverify command line to use gem version validation and incrementing rules.