### PR TITLE
Remove build_metadata from Gem versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,16 +85,15 @@ The output is the following:
 
 ```shell
 Commands:
-  gem-version current [-q]                                              # Show the current gem version
-  gem-version file [-q]                                                 # Show the path to the file containing the g...
-  gem-version help [COMMAND]                                            # Describe available commands or one specifi...
-  gem-version next-major [VERSION] [-p [-t TYPE]] [-b BUILD] [-n] [-q]  # Increment the version's major part
-  gem-version next-minor [VERSION] [-p [-t TYPE]] [-b BUILD] [-n] [-q]  # Increment the version's minor part
-  gem-version next-patch [VERSION] [-p [-t TYPE]] [-b BUILD] [-n] [-q]  # Increment the version's patch part
-  gem-version next-pre [VERSION] [-t TYPE] [-b BUILD] [-n] [-q]         # Increment the version's pre-release part
-  gem-version next-release [VERSION] [-b BUILD] [-n] [-q]               # Increment a pre-release version to the rel...
-  gem-version validate VERSION [-q]                                     # Validate the given version
-$
+  gem-version current [-q]                                   # Show the current gem version
+  gem-version file [-q]                                      # Show the path to the file containing the gem version
+  gem-version help [COMMAND]                                 # Describe available commands or one specific command
+  gem-version next-major [VERSION] [-p [-t TYPE]] [-n] [-q]  # Increment the version's major part
+  gem-version next-minor [VERSION] [-p [-t TYPE]] [-n] [-q]  # Increment the version's minor part
+  gem-version next-patch [VERSION] [-p [-t TYPE]] [-n] [-q]  # Increment the version's patch part
+  gem-version next-pre [VERSION] [-t TYPE] [-n] [-q]         # Increment the version's pre-release part
+  gem-version next-release [VERSION] [-n] [-q]               # Increment a pre-release version to the release version
+  gem-version validate VERSION [-q]                          # Validate the given version
 ```
 
 The `gem-version help COMMAND` command will give further help for a specific command:

--- a/lib/version_boss/gem/command_line.rb
+++ b/lib/version_boss/gem/command_line.rb
@@ -69,7 +69,7 @@ module VersionBoss
         puts version_file.path unless options[:quiet]
       end
 
-      desc 'next-major [VERSION] [-p [-t TYPE]] [-b BUILD] [-n] [-q]', "Increment the version's major part"
+      desc 'next-major [VERSION] [-p [-t TYPE]] [-n] [-q]', "Increment the version's major part"
 
       long_desc <<-LONG_DESC
       Increase the current gem version to the next major version, update the
@@ -103,11 +103,6 @@ module VersionBoss
       is 'alpha', the the command will fail since the new version would sort before the
       existing version ('beta' is not less than or equal to 'alpha').
 
-      Use --build=BUILD to set the build metadata for the new version (See
-      [Build Metadata in the Semantic Versioning Specification](https://semver.org/spec/v2.0.0.html#spec-item-10)).
-      If --build is not given, the incremented version retain the previous build
-      metadata. Pass an empty string to remove the build metadata (--build="")
-
       Use --dry-run to run this command without updating the version file.
 
       Use --quiet to increment the version without producing any output.
@@ -116,7 +111,6 @@ module VersionBoss
       option :pre, type: :boolean, aliases: '-p', desc: 'Create a pre-release version'
       option :'pre-type', type: :string, aliases: '-t', default: 'pre', banner: 'TYPE',
                           desc: 'The type of pre-release version (alpha, beta, etc.)'
-      option :build, type: :string, aliases: '-b', desc: 'The build metadata to add to the version'
       option :'dry-run', type: :boolean, aliases: '-n', desc: 'Do not write the new version to the version file'
       option :quiet, type: :boolean, aliases: '-q', desc: 'Do not print the new version to stdout'
 
@@ -128,7 +122,7 @@ module VersionBoss
         increment_core_version(:next_major, version)
       end
 
-      desc 'next-minor [VERSION] [-p [-t TYPE]] [-b BUILD] [-n] [-q]', "Increment the version's minor part"
+      desc 'next-minor [VERSION] [-p [-t TYPE]] [-n] [-q]', "Increment the version's minor part"
 
       long_desc <<-LONG_DESC
       Increase the current gem version to the next minor version, update the
@@ -162,11 +156,6 @@ module VersionBoss
       is 'alpha', the the command will fail since the new version would sort before the
       existing version ('beta' is not less than or equal to 'alpha').
 
-      Use --build=BUILD to set the build metadata for the new version (See
-      [Build Metadata in the Semantic Versioning Specification](https://semver.org/spec/v2.0.0.html#spec-item-10)).
-      If --build is not given, the incremented version retain the previous build
-      metadata. Pass an empty string to remove the build metadata (--build="")
-
       Use --dry-run to run this command without updating the version file.
 
       Use --quiet to increment the version without producing any output.
@@ -175,7 +164,6 @@ module VersionBoss
       option :pre, type: :boolean, aliases: '-p', desc: 'Create a pre-release version'
       option :'pre-type', type: :string, aliases: '-t', default: 'pre', banner: 'TYPE',
                           desc: 'The type of pre-release version (alpha, beta, etc.)'
-      option :build, type: :string, aliases: '-b', desc: 'The build metadata to add to the version'
       option :'dry-run', type: :boolean, aliases: '-n', desc: 'Do not write the new version to the version file'
       option :quiet, type: :boolean, aliases: '-q', desc: 'Do not print the new version to stdout'
 
@@ -187,7 +175,7 @@ module VersionBoss
         increment_core_version(:next_minor, version)
       end
 
-      desc 'next-patch [VERSION] [-p [-t TYPE]] [-b BUILD] [-n] [-q]', "Increment the version's patch part"
+      desc 'next-patch [VERSION] [-p [-t TYPE]] [-n] [-q]', "Increment the version's patch part"
 
       long_desc <<-LONG_DESC
       Increase the current gem version to the next patch version, update the
@@ -221,11 +209,6 @@ module VersionBoss
       is 'alpha', the the command will fail since the new version would sort before the
       existing version ('beta' is not less than or equal to 'alpha').
 
-      Use --build=BUILD to set the build metadata for the new version (See
-      [Build Metadata in the Semantic Versioning Specification](https://semver.org/spec/v2.0.0.html#spec-item-10)).
-      If --build is not given, the incremented version retain the previous build
-      metadata. Pass an empty string to remove the build metadata (--build="")
-
       Use --dry-run to run this command without updating the version file.
 
       Use --quiet to increment the version without producing any output.
@@ -234,7 +217,6 @@ module VersionBoss
       option :pre, type: :boolean, aliases: '-p', desc: 'Create a pre-release version'
       option :'pre-type', type: :string, aliases: '-t', default: 'pre', banner: 'TYPE',
                           desc: 'The type of pre-release version (alpha, beta, etc.)'
-      option :build, type: :string, aliases: '-b', desc: 'The build metadata to add to the version'
       option :'dry-run', type: :boolean, aliases: '-n', desc: 'Do not write the new version to the version file'
       option :quiet, type: :boolean, aliases: '-q', desc: 'Do not print the new version to stdout'
 
@@ -246,7 +228,7 @@ module VersionBoss
         increment_core_version(:next_patch, version)
       end
 
-      desc 'next-pre [VERSION] [-t TYPE] [-b BUILD] [-n] [-q]', "Increment the version's pre-release part"
+      desc 'next-pre [VERSION] [-t TYPE] [-n] [-q]', "Increment the version's pre-release part"
 
       long_desc <<-LONG_DESC
       Increase the current gem version to the next pre-release version, update the
@@ -287,11 +269,6 @@ module VersionBoss
       given type is 'alpha', then the command will fail since the new version would sort
       before the existing version (since 'beta' is not <= 'alpha').
 
-      Use --build=BUILD to set the build metadata for the new version (See
-      [Build Metadata in the Semantic Versioning Specification](https://semver.org/spec/v2.0.0.html#spec-item-10)).
-      If --build is not given, the incremented version retain the previous build
-      metadata. Pass an empty string to remove the build metadata (--build="")
-
       Use --dry-run to run this command without updating the version file.
 
       Use --quiet to increment the version without producing any output.
@@ -299,7 +276,6 @@ module VersionBoss
 
       option :'pre-type', type: :string, aliases: '-t', banner: 'TYPE',
                           desc: 'The type of pre-release version (alpha, beta, etc.)'
-      option :build, type: :string, aliases: '-b', desc: 'The build metadata to add to the version'
       option :'dry-run', type: :boolean, aliases: '-n', desc: 'Do not write the new version to the version file'
       option :quiet, type: :boolean, aliases: '-q', desc: 'Do not print the new version to stdout'
 
@@ -310,14 +286,13 @@ module VersionBoss
       def next_pre(version = nil)
         args = {}
         args[:pre_type] = options[:'pre-type'] if options[:'pre-type']
-        args[:build_metadata] = options[:build] if options[:build]
 
         new_version = increment_version(:next_pre, args, version)
 
         puts new_version unless options[:quiet]
       end
 
-      desc 'next-release [VERSION] [-b BUILD] [-n] [-q]', 'Increment a pre-release version to the release version'
+      desc 'next-release [VERSION] [-n] [-q]', 'Increment a pre-release version to the release version'
 
       long_desc <<-LONG_DESC
       Increase the current gem version to the next release version, update the
@@ -332,17 +307,11 @@ module VersionBoss
       VERSION implies --dry-run. The command fails if VERSION is not a valid
       pre-release version.
 
-      Use --build=BUILD to set the build metadata for the new version (See
-      [Build Metadata in the Semantic Versioning Specification](https://semver.org/spec/v2.0.0.html#spec-item-10)).
-      If --build is not given, the incremented version retain the previous build
-      metadata. Pass an empty string to remove the build metadata (--build="")
-
       Use --dry-run to run this command without updating the version file.
 
       Use --quiet to increment the version without producing any output.
       LONG_DESC
 
-      option :build, type: :string, aliases: '-b', desc: 'The build metadata to add to the version'
       option :'dry-run', type: :boolean, aliases: '-n', desc: 'Do not write the new version to the version file'
       option :quiet, type: :boolean, aliases: '-q', desc: 'Do not print the new version to stdout'
 
@@ -352,8 +321,6 @@ module VersionBoss
       # @return [void]
       def next_release(version = nil)
         args = {}
-        args[:build_metadata] = options[:build] if options[:build]
-
         new_version = increment_version(:next_release, args, version)
 
         puts new_version unless options[:quiet]
@@ -397,7 +364,6 @@ module VersionBoss
         {}.tap do |args|
           args[:pre] = options[:pre] if options[:pre]
           args[:pre_type] = options[:'pre-type'] if options[:'pre-type']
-          args[:build_metadata] = options[:build] if options[:build]
         end
       end
 

--- a/lib/version_boss/gem/incrementable_version.rb
+++ b/lib/version_boss/gem/incrementable_version.rb
@@ -52,11 +52,9 @@ module VersionBoss
       #
       # @return [IncrementableVersion] a new IncrementableVersion object with the major version incremented
       #
-      def next_major(pre: false, pre_type: DEFAULT_PRE_TYPE, build_metadata: nil)
+      def next_major(pre: false, pre_type: DEFAULT_PRE_TYPE)
         version_string = "#{major.to_i + 1}.0.0"
         version_string += ".#{pre_type}.1" if pre
-        build_metadata = self.build_metadata if build_metadata.nil?
-        version_string += "+#{build_metadata}" unless build_metadata.empty?
         IncrementableVersion.new(version_string)
       end
 
@@ -68,11 +66,9 @@ module VersionBoss
       #
       # @return [IncrementableVersion] a new IncrementableVersion object with the major version incremented
       #
-      def next_minor(pre: false, pre_type: DEFAULT_PRE_TYPE, build_metadata: nil)
+      def next_minor(pre: false, pre_type: DEFAULT_PRE_TYPE)
         version_string = "#{major}.#{minor.to_i + 1}.0"
         version_string += ".#{pre_type}.1" if pre
-        build_metadata = self.build_metadata if build_metadata.nil?
-        version_string += "+#{build_metadata}" unless build_metadata.empty?
         IncrementableVersion.new(version_string)
       end
 
@@ -84,11 +80,9 @@ module VersionBoss
       #
       # @return [IncrementableVersion] a new IncrementableVersion object with the patch part incremented
       #
-      def next_patch(pre: false, pre_type: DEFAULT_PRE_TYPE, build_metadata: nil)
+      def next_patch(pre: false, pre_type: DEFAULT_PRE_TYPE)
         version_string = "#{major}.#{minor}.#{patch.to_i + 1}"
         version_string += ".#{pre_type}.1" if pre
-        build_metadata = self.build_metadata if build_metadata.nil?
-        version_string += "+#{build_metadata}" unless build_metadata.empty?
         IncrementableVersion.new(version_string)
       end
 
@@ -99,12 +93,10 @@ module VersionBoss
       #
       # @return [IncrementableVersion] a new object with the pre_release part incremented
       #
-      def next_pre(pre_type: nil, build_metadata: nil)
+      def next_pre(pre_type: nil)
         assert_is_a_pre_release_version
         version_string = "#{major}.#{minor}.#{patch}"
         version_string += next_pre_part(pre_type)
-        build_metadata ||= self.build_metadata
-        version_string += "+#{build_metadata}" unless build_metadata.empty?
         IncrementableVersion.new(version_string)
       end
 
@@ -116,11 +108,9 @@ module VersionBoss
       # @return [IncrementableVersion] a new IncrementableVersion object with the pre_release part dropped
       # @raise [VersionBoss::Error] if the version is not a pre-release version
       #
-      def next_release(build_metadata: nil)
+      def next_release
         assert_is_a_pre_release_version
         version_string = "#{major}.#{minor}.#{patch}"
-        build_metadata ||= self.build_metadata
-        version_string += "+#{build_metadata}" unless build_metadata.empty?
         IncrementableVersion.new(version_string)
       end
 

--- a/lib/version_boss/gem/version.rb
+++ b/lib/version_boss/gem/version.rb
@@ -164,26 +164,6 @@ module VersionBoss
       #
       attr_reader :pre_release_identifiers
 
-      # @attribute build_metadata [r]
-      #
-      # The build_metadata part of the version
-      #
-      # Will be an empty string if the version has no build_metadata part.
-      #
-      # @example
-      #   gem_version = VersionBoss::GemVersion.new('1.2.3.alpha.1+build.001')
-      #   gem_version.build_metadata #=> 'build.001'
-      #
-      # @example When the version has no build_metadata part
-      #   gem_version = VersionBoss::GemVersion.new('1.2.3')
-      #   gem_version.build_metadata #=> ''
-      #
-      # @return [String]
-      #
-      # @api public
-      #
-      attr_reader :build_metadata
-
       # Compare two GemVersion objects
       #
       # See the [Precedence Rules](https://gem_version.org/spec/v2.0.0.html#spec-item-11)
@@ -284,7 +264,6 @@ module VersionBoss
 
         core_parts(match_data)
         pre_release_part(match_data)
-        build_metadata_part(match_data)
       end
 
       # Compare the major, minor, and patch parts of this GemVersion to other
@@ -332,13 +311,13 @@ module VersionBoss
         pre_release_identifiers.size < other.pre_release_identifiers.size ? -1 : 0
       end
 
-      # Raise a error if other is not a valid Semver
+      # Raise a error if other is not a valid Gem version
       # @param other [GemVersion] the other to check
       # @return [void]
-      # @raise [VersionBoss::Error] if other is not a valid Semver
+      # @raise [VersionBoss::Error] if other is not a valid Gem version
       # @api private
       def assert_other_is_a_gem_version(other)
-        raise VersionBoss::Error, 'other must be a Semver' unless other.is_a?(Version)
+        raise VersionBoss::Error, 'other must be a VersionBoss::Gem::Version' unless other.is_a?(Version)
       end
 
       # Raise a error if the given version is not a string
@@ -350,15 +329,15 @@ module VersionBoss
         raise VersionBoss::Error, 'Version must be a string' unless version.is_a?(String)
       end
 
-      # Raise a error if this version object is not a valid Semver
+      # Raise a error if this version object is not a valid Gem version
       # @return [void]
-      # @raise [VersionBoss::Error] if other is not a valid Semver
+      # @raise [VersionBoss::Error] if other is not a valid Gem version
       # @api private
       def assert_valid_version
         raise VersionBoss::Error, "Not a valid version string: #{version}" unless valid?
       end
 
-      # Set the major, minor, and patch parts of this Semver
+      # Set the major, minor, and patch parts of this version
       # @param match_data [MatchData] the match data from the version string
       # @return [void]
       # @api private
@@ -368,21 +347,13 @@ module VersionBoss
         @patch = match_data[:patch]
       end
 
-      # Set the pre-release of this Semver
+      # Set the pre-release of this version
       # @param match_data [MatchData] the match data from the version string
       # @return [void]
       # @api private
       def pre_release_part(match_data)
         @pre_release = match_data[:pre_release] || ''
         @pre_release_identifiers = tokenize_pre_release_part(@pre_release)
-      end
-
-      # Set the build_metadata of this Semver
-      # @param match_data [MatchData] the match data from the version string
-      # @return [void]
-      # @api private
-      def build_metadata_part(_match_data)
-        @build_metadata = ''
       end
 
       # A pre-release part of a version which consists of an optional prefix and an identifier

--- a/lib/version_boss/semver/command_line.rb
+++ b/lib/version_boss/semver/command_line.rb
@@ -1,0 +1,474 @@
+# frozen_string_literal: true
+
+# require 'thor'
+
+# module VersionBoss
+#   module Semver
+#     # The version_boss cli
+#     #
+#     # @example
+#     #   require 'version_boss'
+#     #
+#     #   VersionBoss::CommandLine.start(ARGV)
+#     #
+#     # @api private
+#     #
+#     class CommandLine < Thor
+#       # Tell Thor to exit with a non-zero status code if a command fails
+#       def self.exit_on_failure? = true
+
+#       desc 'current [-q]', 'Show the current gem version'
+
+#       long_desc <<-LONG_DESC
+#       Output the current gem version from the file that stores the gem version.
+
+#       The command fails if the gem version could not be found or is invalid.
+
+#       Use `--quiet` to ensure that a gem version could be found and is valid without producing any output.
+#       LONG_DESC
+
+#       option :quiet, type: :boolean, aliases: '-q', desc: 'Do not print the current version to stdout'
+
+#       # Show the current gem version
+#       # @return [void]
+#       def current
+#         version_file = VersionBoss::Gem::VersionFileFactory.find
+
+#         if version_file.nil?
+#           warn 'version file not found or is not valid' unless options[:quiet]
+#           exit 1
+#         end
+
+#         puts version_file.version unless options[:quiet]
+#       end
+
+#       desc 'file [-q]', 'Show the path to the file containing the gem version'
+
+#       long_desc <<-LONG_DESC
+#       Output the relative path to the file that stores the gem version.
+
+#       The command fails if the gem version could not be found.
+
+#       Use `--quiet` to ensure that a gem version could be found without producing any output.
+#       LONG_DESC
+
+#       option :quiet, type: :boolean, aliases: '-q', desc: 'Do not print the version file path to stdout'
+
+#       # Show the gem's version file
+#       # @return [void]
+#       def file
+#         version_file = VersionBoss::Gem::VersionFileFactory.find
+
+#         if version_file.nil?
+#           warn 'version file not found or is not valid' unless options[:quiet]
+#           exit 1
+#         end
+
+#         puts version_file.path unless options[:quiet]
+#       end
+
+#       desc 'next-major [VERSION] [-p [-t TYPE]] [-b BUILD] [-n] [-q]', "Increment the version's major part"
+
+#       long_desc <<-LONG_DESC
+#       Increase the current gem version to the next major version, update the
+#       file that stores the version, and output the resulting version to stdout.
+
+#       Increments 1.x.y to 2.0.0.
+
+#       The command fails if the current gem version file could not be found or
+#       if the version is not valid.
+
+#       If VERSION is given, use that instead of the current gem version. Giving
+#       VERSION implies --dry-run. The command fails if VERSION is not valid.
+
+#       --pre can be used to specify that the version should be incremented AND
+#       given a pre-release part. For instance:
+
+#       $ version_boss next-major --pre
+
+#       increments '1.2.3' to '2.0.0.pre.1'.
+
+#       By default, the pre-release type is 'pre'. --pre-type=TYPE can be used with
+#       --pre to specify a different pre-release type such as alpha, beta, rc, etc.
+#       For instance:
+
+#       $ version_boss next-major --pre --pre-type=alpha
+
+#       increments '1.2.3' to '2.0.0-alpha.1'.
+
+#       The command fails if the existing pre-release type is not lexically less than or
+#       equal to TYPE. For example, it the current version is '1.2.3-beta.1' and TYPE
+#       is 'alpha', the the command will fail since the new version would sort before the
+#       existing version ('beta' is not less than or equal to 'alpha').
+
+#       Use --build=BUILD to set the build metadata for the new version (See
+#       [Build Metadata in the Semantic Versioning Specification](https://semver.org/spec/v2.0.0.html#spec-item-10)).
+#       If --build is not given, the incremented version retain the previous build
+#       metadata. Pass an empty string to remove the build metadata (--build="")
+
+#       Use --dry-run to run this command without updating the version file.
+
+#       Use --quiet to increment the version without producing any output.
+#       LONG_DESC
+
+#       option :pre, type: :boolean, aliases: '-p', desc: 'Create a pre-release version'
+#       option :'pre-type', type: :string, aliases: '-t', default: 'pre', banner: 'TYPE',
+#                           desc: 'The type of pre-release version (alpha, beta, etc.)'
+#       option :build, type: :string, aliases: '-b', desc: 'The build metadata to add to the version'
+#       option :'dry-run', type: :boolean, aliases: '-n', desc: 'Do not write the new version to the version file'
+#       option :quiet, type: :boolean, aliases: '-q', desc: 'Do not print the new version to stdout'
+
+#       # Increment the gem version's major part
+#       # @param version [String, nil] The version to increment or nil to use the version
+#       #   from the gem's version file
+#       # @return [void]
+#       def next_major(version = nil)
+#         increment_core_version(:next_major, version)
+#       end
+
+#       desc 'next-minor [VERSION] [-p [-t TYPE]] [-b BUILD] [-n] [-q]', "Increment the version's minor part"
+
+#       long_desc <<-LONG_DESC
+#       Increase the current gem version to the next minor version, update the
+#       file that stores the version, and output the resulting version to stdout.
+
+#       Increments 1.2.y to 1.3.0.
+
+#       The command fails if the current gem version file could not be found or
+#       if the version is not valid.
+
+#       If VERSION is given, use that instead of the current gem version. Giving
+#       VERSION implies --dry-run. The command fails if VERSION is not valid.
+
+#       --pre can be used to specify that the version should be incremented AND
+#       given a pre-release part. For instance:
+
+#       $ version_boss next-minor --pre
+
+#       increments '1.2.3' to '2.0.0.pre.1'.
+
+#       By default, the pre-release type is 'pre'. --pre-type=TYPE can be used with
+#       --pre to specify a different pre-release type such as alpha, beta, rc, etc.
+#       For instance:
+
+#       $ version_boss next-patch --pre --pre-type=alpha
+
+#       increments '1.2.3' to '1.2.4-alpha.1'.
+
+#       The command fails if the existing pre-release type is not lexically less than or
+#       equal to TYPE. For example, it the current version is '1.2.3-beta.1' and TYPE
+#       is 'alpha', the the command will fail since the new version would sort before the
+#       existing version ('beta' is not less than or equal to 'alpha').
+
+#       Use --build=BUILD to set the build metadata for the new version (See
+#       [Build Metadata in the Semantic Versioning Specification](https://semver.org/spec/v2.0.0.html#spec-item-10)).
+#       If --build is not given, the incremented version retain the previous build
+#       metadata. Pass an empty string to remove the build metadata (--build="")
+
+#       Use --dry-run to run this command without updating the version file.
+
+#       Use --quiet to increment the version without producing any output.
+#       LONG_DESC
+
+#       option :pre, type: :boolean, aliases: '-p', desc: 'Create a pre-release version'
+#       option :'pre-type', type: :string, aliases: '-t', default: 'pre', banner: 'TYPE',
+#                           desc: 'The type of pre-release version (alpha, beta, etc.)'
+#       option :build, type: :string, aliases: '-b', desc: 'The build metadata to add to the version'
+#       option :'dry-run', type: :boolean, aliases: '-n', desc: 'Do not write the new version to the version file'
+#       option :quiet, type: :boolean, aliases: '-q', desc: 'Do not print the new version to stdout'
+
+#       # Increment the gem version's minor part
+#       # @param version [String, nil] The version to increment or nil to use the version
+#       #   from the gem's version file
+#       # @return [void]
+#       def next_minor(version = nil)
+#         increment_core_version(:next_minor, version)
+#       end
+
+#       desc 'next-patch [VERSION] [-p [-t TYPE]] [-b BUILD] [-n] [-q]', "Increment the version's patch part"
+
+#       long_desc <<-LONG_DESC
+#       Increase the current gem version to the next patch version, update the
+#       file that stores the version, and output the resulting version to stdout.
+
+#       Increments 1.2.3 to 1.2.4.
+
+#       The command fails if the current gem version file could not be found or
+#       if the version is not valid.
+
+#       If VERSION is given, use that instead of the current gem version. Giving
+#       VERSION implies --dry-run. The command fails if VERSION is not valid.
+
+#       --pre can be used to specify that the version should be incremented AND
+#       given a pre-release part. For instance:
+
+#       $ version_boss next-patch --pre
+
+#       increments '1.2.3' to '1.2.4.pre.1'.
+
+#       By default, the pre-release type is 'pre'. --pre-type=TYPE can be used with
+#       --pre to specify a different pre-release type such as alpha, beta, rc, etc.
+#       For instance:
+
+#       $ version_boss next-patch --pre --pre-type=alpha
+
+#       increments '1.2.3' to '1.2.4-alpha.1'.
+
+#       The command fails if the existing pre-release type is not lexically less than or
+#       equal to TYPE. For example, it the current version is '1.2.3-beta.1' and TYPE
+#       is 'alpha', the the command will fail since the new version would sort before the
+#       existing version ('beta' is not less than or equal to 'alpha').
+
+#       Use --build=BUILD to set the build metadata for the new version (See
+#       [Build Metadata in the Semantic Versioning Specification](https://semver.org/spec/v2.0.0.html#spec-item-10)).
+#       If --build is not given, the incremented version retain the previous build
+#       metadata. Pass an empty string to remove the build metadata (--build="")
+
+#       Use --dry-run to run this command without updating the version file.
+
+#       Use --quiet to increment the version without producing any output.
+#       LONG_DESC
+
+#       option :pre, type: :boolean, aliases: '-p', desc: 'Create a pre-release version'
+#       option :'pre-type', type: :string, aliases: '-t', default: 'pre', banner: 'TYPE',
+#                           desc: 'The type of pre-release version (alpha, beta, etc.)'
+#       option :build, type: :string, aliases: '-b', desc: 'The build metadata to add to the version'
+#       option :'dry-run', type: :boolean, aliases: '-n', desc: 'Do not write the new version to the version file'
+#       option :quiet, type: :boolean, aliases: '-q', desc: 'Do not print the new version to stdout'
+
+#       # Increment the gem version's patch part
+#       # @param version [String, nil] The version to increment or nil to use the version
+#       #   from the gem's version file
+#       # @return [void]
+#       def next_patch(version = nil)
+#         increment_core_version(:next_patch, version)
+#       end
+
+#       desc 'next-pre [VERSION] [-t TYPE] [-b BUILD] [-n] [-q]', "Increment the version's pre-release part"
+
+#       long_desc <<-LONG_DESC
+#       Increase the current gem version to the next pre-release version, update the
+#       file that stores the version, and output the resulting version to stdout.
+
+#       The command fails if  the current gem version file could not be found or
+#       the version is not a valid pre-release version.
+
+#       If VERSION is given, use that instead of the current gem version. Giving
+#       VERSION implies --dry-run. The command fails if VERSION is not a valid
+#       pre-release version.
+
+#       By default, the existing pre-release type is preserved. For instance:
+
+#       $ version_boss next-pre
+
+#       Increments 1.2.3-alpha.1 to 1.2.3-alpha.2.
+
+#       --pre-type=TYPE can be used to change the pre-release type to TYPE (typical
+#       examples include alpha, beta, rc, etc.). If the pre-release type is changed,
+#       the pre-release number is reset to 1.
+
+#       For example, if the version starts as 1.2.3-alpha.4, then:
+
+#       $ version_boss current
+#       1.2.3-alpha.4
+#       $ semver next-pre --pre-type=beta
+#       1.2.3-beta.1
+#       $ semver next-pre --pre-type=beta
+#       1.2.3-beta.2
+#       $ semver next-pre --pre-type=rc
+#       1.2.3-rc.1
+#       $ version_boss next-release
+#       1.2.3
+
+#       The command fails if the existing pre-release type is not lexically less than or
+#       equal to TYPE. For example, it the current version is '1.2.3-beta.1' and the TYPE
+#       given type is 'alpha', then the command will fail since the new version would sort
+#       before the existing version (since 'beta' is not <= 'alpha').
+
+#       Use --build=BUILD to set the build metadata for the new version (See
+#       [Build Metadata in the Semantic Versioning Specification](https://semver.org/spec/v2.0.0.html#spec-item-10)).
+#       If --build is not given, the incremented version retain the previous build
+#       metadata. Pass an empty string to remove the build metadata (--build="")
+
+#       Use --dry-run to run this command without updating the version file.
+
+#       Use --quiet to increment the version without producing any output.
+#       LONG_DESC
+
+#       option :'pre-type', type: :string, aliases: '-t', banner: 'TYPE',
+#                           desc: 'The type of pre-release version (alpha, beta, etc.)'
+#       option :build, type: :string, aliases: '-b', desc: 'The build metadata to add to the version'
+#       option :'dry-run', type: :boolean, aliases: '-n', desc: 'Do not write the new version to the version file'
+#       option :quiet, type: :boolean, aliases: '-q', desc: 'Do not print the new version to stdout'
+
+#       # Increment the gem version's pre-release part
+#       # @param version [String, nil] The version to increment or nil to use the version
+#       #   from the gem's version file
+#       # @return [void]
+#       def next_pre(version = nil)
+#         args = {}
+#         args[:pre_type] = options[:'pre-type'] if options[:'pre-type']
+#         args[:build_metadata] = options[:build] if options[:build]
+
+#         new_version = increment_version(:next_pre, args, version)
+
+#         puts new_version unless options[:quiet]
+#       end
+
+#       desc 'next-release [VERSION] [-b BUILD] [-n] [-q]', 'Increment a pre-release version to the release version'
+
+#       long_desc <<-LONG_DESC
+#       Increase the current gem version to the next release version, update the
+#       file that stores the version, and output the resulting version to stdout.
+
+#       Increments 1.2.3-rc.4 to 1.2.3.
+
+#       The command fails if the current gem version file could not be found or
+#       the version is not a valid pre-release version.
+
+#       If VERSION is given, use that instead of the current gem version. Giving
+#       VERSION implies --dry-run. The command fails if VERSION is not a valid
+#       pre-release version.
+
+#       Use --build=BUILD to set the build metadata for the new version (See
+#       [Build Metadata in the Semantic Versioning Specification](https://semver.org/spec/v2.0.0.html#spec-item-10)).
+#       If --build is not given, the incremented version retain the previous build
+#       metadata. Pass an empty string to remove the build metadata (--build="")
+
+#       Use --dry-run to run this command without updating the version file.
+
+#       Use --quiet to increment the version without producing any output.
+#       LONG_DESC
+
+#       option :build, type: :string, aliases: '-b', desc: 'The build metadata to add to the version'
+#       option :'dry-run', type: :boolean, aliases: '-n', desc: 'Do not write the new version to the version file'
+#       option :quiet, type: :boolean, aliases: '-q', desc: 'Do not print the new version to stdout'
+
+#       # Increment the gem's pre-release version to a release version
+#       # @param version [String, nil] The version to increment or nil to use the version
+#       #   from the gem's version file
+#       # @return [void]
+#       def next_release(version = nil)
+#         args = {}
+#         args[:build_metadata] = options[:build] if options[:build]
+
+#         new_version = increment_version(:next_release, args, version)
+
+#         puts new_version unless options[:quiet]
+#       end
+
+#       desc 'validate VERSION [-q]', 'Validate the given version'
+
+#       long_desc <<-LONG_DESC
+#       Validate and output the given gem version.
+
+#       The command fails if the gem version is not valid.
+
+#       Use `--quiet` to validate the gem version without producing any output.
+#       LONG_DESC
+
+#       option :quiet, type: :boolean, aliases: '-q', desc: 'Do not print the given version to stdout'
+
+#       # Validate that the give version is a valid IncrementableSemver version
+#       # @param version [String] The version to validate
+#       # @return [void]
+#       #
+#       def validate(version)
+#         VersionBoss::Gem::IncrementableVersion.new(version)
+#       rescue VersionBoss::Error => e
+#         warn e.message unless options[:quiet]
+#         exit 1
+#       else
+#         puts version unless options[:quiet]
+#       end
+
+#       private
+
+#       # Build a hash of arguments to pass to the IncrementableSemver methods
+#       #
+#       # These arguments are specificly for the #next_major, #next_minor, and
+#       # #next_patch method.
+#       #
+#       # @return [Hash]
+#       #
+#       def core_args
+#         {}.tap do |args|
+#           args[:pre] = options[:pre] if options[:pre]
+#           args[:pre_type] = options[:'pre-type'] if options[:'pre-type']
+#           args[:build_metadata] = options[:build] if options[:build]
+#         end
+#       end
+
+#       # Increment the gem's major, minor, or patch version
+#       #
+#       # @param method [Symbol] The method to call on the IncrementableSemver object
+#       # @param version [String, nil] The version to increment or nil to use the version
+#       #  from the gem's version file
+#       #
+#       # @return [Void]
+#       #
+#       def increment_core_version(method, version)
+#         new_version = increment_version(method, core_args, version)
+
+#         puts new_version unless options[:quiet]
+#       end
+
+#       # Increment the gem's version
+#       #
+#       # @param method [Symbol] The method to call on the IncrementableSemver object
+#       #
+#       #   The method can bee one of: :next_major, :next_minor, :next_patch, :next_pre, :next_release
+#       #
+#       # @param args [Hash] The arguments to pass to the method
+#       #
+#       # @param version [String, nil] The version to increment or nil to use the version
+#       #
+#       # @return [Void]
+#       #
+#       def increment_version(method, args, version)
+#         if version
+#           increment_literal_version(method, args, version)
+#         else
+#           increment_gem_version(method, args)
+#         end
+#       rescue VersionBoss::Error => e
+#         warn e.message unless options[:quiet]
+#         exit 1
+#       end
+
+#       # Increment a literal version from a string
+#       #
+#       # @param method [Symbol] The method to call on the IncrementableSemver object
+#       # @param args [Hash] The arguments to pass to the method
+#       # @param version [String] The version to increment
+#       #
+#       # @return [VersionBoss::IncrementableRubyVersion] the incremented version
+#       # @raise [VersionBoss::Error] if the version is not a valid IncrementableSemver version
+#       #
+#       def increment_literal_version(method, args, version)
+#         VersionBoss::Gem::IncrementableVersion.new(version).send(method, **args)
+#       end
+
+#       # Increment the gem's version from the gem's version file
+#       #
+#       # @param method [Symbol] The method to call on the IncrementableSemver object
+#       # @param args [Hash] The arguments to pass to the method
+#       #
+#       # @return [VersionBoss::IncrementableRubyVersion] the incremented version
+#       # @raise [VersionBoss::Error] if the version is not a valid IncrementableSemver version
+#       #
+#       def increment_gem_version(method, args)
+#         version_file = VersionBoss::Gem::VersionFileFactory.find
+
+#         if version_file.nil?
+#           warn 'version file not found or is not valid' unless options[:quiet]
+#           exit 1
+#         end
+
+#         version_file&.version.send(method, **args).tap do |new_version|
+#           version_file.version = new_version unless options[:'dry-run']
+#         end
+#       end
+#     end
+#   end
+# end

--- a/spec/version_boss/gem/version_spec.rb
+++ b/spec/version_boss/gem/version_spec.rb
@@ -40,8 +40,7 @@ RSpec.describe VersionBoss::Gem::Version do
             major: '1',
             minor: '2',
             patch: '3',
-            pre_release: '',
-            build_metadata: ''
+            pre_release: ''
           )
         )
       end
@@ -55,8 +54,7 @@ RSpec.describe VersionBoss::Gem::Version do
             major: '1',
             minor: '2',
             patch: '3',
-            pre_release: '.pre.1',
-            build_metadata: ''
+            pre_release: '.pre.1'
           )
         )
       end


### PR DESCRIPTION
RubyGems versions do not support Semver build metadata as part of the version.

Remove the build_metadata attribute from VersionBoss::Gem::Version classes and tests and from the VersionBoss::Gem::CommandLine.

Preserve the CommandLine with the build_metadata options in the VersionBoss::Semver module for future use.