### PR TITLE
Create prerelease without dot like "1.0.0.pre1" instead of "1.0.0.pre.1"

### DIFF
--- a/lib/version_boss/gem/incrementable_version.rb
+++ b/lib/version_boss/gem/incrementable_version.rb
@@ -54,7 +54,7 @@ module VersionBoss
       #
       def next_major(pre: false, pre_type: DEFAULT_PRE_TYPE)
         version_string = "#{major.to_i + 1}.0.0"
-        version_string += ".#{pre_type}.1" if pre
+        version_string += ".#{pre_type}1" if pre
         IncrementableVersion.new(version_string)
       end
 
@@ -68,7 +68,7 @@ module VersionBoss
       #
       def next_minor(pre: false, pre_type: DEFAULT_PRE_TYPE)
         version_string = "#{major}.#{minor.to_i + 1}.0"
-        version_string += ".#{pre_type}.1" if pre
+        version_string += ".#{pre_type}1" if pre
         IncrementableVersion.new(version_string)
       end
 
@@ -82,7 +82,7 @@ module VersionBoss
       #
       def next_patch(pre: false, pre_type: DEFAULT_PRE_TYPE)
         version_string = "#{major}.#{minor}.#{patch.to_i + 1}"
-        version_string += ".#{pre_type}.1" if pre
+        version_string += ".#{pre_type}1" if pre
         IncrementableVersion.new(version_string)
       end
 
@@ -117,7 +117,7 @@ module VersionBoss
       # The pre-release type (for example, 'alpha', 'beta', 'pre', etc.)
       #
       # @example
-      #   VersionBoss::IncrementableVersion.new('1.2.3.pre.1').pre_type # => 'pre'
+      #   VersionBoss::IncrementableVersion.new('1.2.3.pre1').pre_type # => 'pre'
       #
       # @return [String]
       #
@@ -130,11 +130,11 @@ module VersionBoss
       # Ruby Gem versions can optionally prefix the pre-release type with a period.
       #
       # @example
-      #   VersionBoss::GemVersion.new('1.2.3.pre.1').pre_type_prefix # => '-'
+      #   VersionBoss::GemVersion.new('1.2.3.pre1').pre_type_prefix # => '-'
       # Semver requires a hyphen prefix.
       #
       # @example
-      #   VersionBoss::IncrementableVersion.new('1.2.3.pre.1').pre_type # => 'pre'
+      #   VersionBoss::IncrementableVersion.new('1.2.3.pre1').pre_type # => 'pre'
       #
       # @return ['.', '']
       #

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -254,15 +254,15 @@ RSpec.shared_examples 'Gem Core Version Incrementer' do |part, from_version, to_
 
     context 'when --pre is given' do
       let(:args) { [version, '--pre'] }
-      it "should output #{to_version}.pre.1 (use the default pre-release type 'pre')" do
-        expect { subject }.to output("#{to_version}.pre.1\n").to_stdout
+      it "should output #{to_version}.pre1 (use the default pre-release type 'pre')" do
+        expect { subject }.to output("#{to_version}.pre1\n").to_stdout
       end
     end
 
     context 'when --pre and --pre-type=alpha are given' do
       let(:args) { [version, '--pre', '--pre-type=alpha'] }
-      it "should output #{to_version}.alpha.1 (use the given pre-release type)" do
-        expect { subject }.to output("#{to_version}.alpha.1\n").to_stdout
+      it "should output #{to_version}.alpha1 (use the given pre-release type)" do
+        expect { subject }.to output("#{to_version}.alpha1\n").to_stdout
       end
     end
   end
@@ -278,16 +278,16 @@ RSpec.shared_examples 'Gem Core Version Incrementer' do |part, from_version, to_
     context 'when given the --pre option' do
       let(:args) { [version, '--pre'] }
 
-      it "should output #{to_version}.pre.1 (using the default pre-release type 'pre')" do
-        expect { subject }.to output("#{to_version}.pre.1\n").to_stdout
+      it "should output #{to_version}.pre1 (using the default pre-release type 'pre')" do
+        expect { subject }.to output("#{to_version}.pre1\n").to_stdout
       end
     end
 
     context 'when given the --pre and --pre-type=alpha options' do
       let(:args) { [version, '--pre', '--pre-type=alpha'] }
 
-      it "should output #{to_version}.alpha.1 (using the pre-release type given)" do
-        expect { subject }.to output("#{to_version}.alpha.1\n").to_stdout
+      it "should output #{to_version}.alpha1 (using the pre-release type given)" do
+        expect { subject }.to output("#{to_version}.alpha1\n").to_stdout
       end
     end
 

--- a/spec/version_boss/gem/incrementable_version_spec.rb
+++ b/spec/version_boss/gem/incrementable_version_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe VersionBoss::Gem::IncrementableVersion do
       context 'when arg pre: true is given' do
         let(:args) { { pre: true } }
         let(:version) { '1.2.3' }
-        let(:expected_version) { described_class.new('2.0.0.pre.1') }
-        it 'should increment the major part and set the pre-release part to "pre.1"' do
+        let(:expected_version) { described_class.new('2.0.0.pre1') }
+        it 'should increment the major part and set the pre-release part to "pre1"' do
           expect(subject).to eq(expected_version)
         end
       end
@@ -64,8 +64,8 @@ RSpec.describe VersionBoss::Gem::IncrementableVersion do
       context "when args pre: true, pre_suffix: 'alpha' are given" do
         let(:args) { { pre: true, pre_type: 'alpha' } }
         let(:version) { '1.2.3' }
-        let(:expected_version) { described_class.new('2.0.0.alpha.1') }
-        it 'should increment the major part and set the pre-release part to "alpha.1"' do
+        let(:expected_version) { described_class.new('2.0.0.alpha1') }
+        it 'should increment the major part and set the pre-release part to "alpha1"' do
           expect(subject).to eq(expected_version)
         end
       end
@@ -73,7 +73,7 @@ RSpec.describe VersionBoss::Gem::IncrementableVersion do
 
     context 'when the version has a pre-release part' do
       context 'with out any args' do
-        let(:version) { '1.2.3.alpha.1' }
+        let(:version) { '1.2.3.alpha1' }
         let(:expected_version) { described_class.new('2.0.0') }
         it 'should increment the major part and clear the pre-release part' do
           expect(subject).to eq(expected_version)
@@ -82,18 +82,18 @@ RSpec.describe VersionBoss::Gem::IncrementableVersion do
 
       context 'when the arg pre: true is given' do
         let(:args) { { pre: true } }
-        let(:version) { '1.2.3.pre.3' }
-        let(:expected_version) { described_class.new('2.0.0.pre.1') }
-        it "should increment the major part and set pre-release part to 'pre.1'" do
+        let(:version) { '1.2.3.pre3' }
+        let(:expected_version) { described_class.new('2.0.0.pre1') }
+        it "should increment the major part and set pre-release part to 'pre1'" do
           expect(subject).to eq(expected_version)
         end
       end
 
       context 'when the args pre: true, pre_type: "alpha" are given' do
         let(:args) { { pre: true, pre_type: 'alpha' } }
-        let(:version) { '1.2.3.pre.3' }
-        let(:expected_version) { described_class.new('2.0.0.alpha.1') }
-        it "should increment the major part and set pre-release part to 'alpha.1'" do
+        let(:version) { '1.2.3.pre3' }
+        let(:expected_version) { described_class.new('2.0.0.alpha1') }
+        it "should increment the major part and set pre-release part to 'alpha1'" do
           expect(subject).to eq(expected_version)
         end
       end
@@ -115,8 +115,8 @@ RSpec.describe VersionBoss::Gem::IncrementableVersion do
       context 'when arg pre: true is given' do
         let(:args) { { pre: true } }
         let(:version) { '1.2.3' }
-        let(:expected_version) { described_class.new('1.3.0.pre.1') }
-        it 'should incrementthe minor part and set the pre-release part to "pre.1"' do
+        let(:expected_version) { described_class.new('1.3.0.pre1') }
+        it 'should incrementthe minor part and set the pre-release part to "pre1"' do
           expect(subject).to eq(expected_version)
         end
       end
@@ -124,8 +124,8 @@ RSpec.describe VersionBoss::Gem::IncrementableVersion do
       context "when args pre: true, pre_suffix: 'alpha' are given" do
         let(:args) { { pre: true, pre_type: 'alpha' } }
         let(:version) { '1.2.3' }
-        let(:expected_version) { described_class.new('1.3.0.alpha.1') }
-        it 'should increment the minor part and set the pre-release part to "alpha.1"' do
+        let(:expected_version) { described_class.new('1.3.0.alpha1') }
+        it 'should increment the minor part and set the pre-release part to "alpha1"' do
           expect(subject).to eq(expected_version)
         end
       end
@@ -133,7 +133,7 @@ RSpec.describe VersionBoss::Gem::IncrementableVersion do
 
     context 'when the version has a pre-release part' do
       context 'with out any args' do
-        let(:version) { '1.2.3.alpha.1' }
+        let(:version) { '1.2.3.alpha1' }
         let(:expected_version) { described_class.new('1.3.0') }
         it 'should increment the minor part and clear the pre-release part' do
           expect(subject).to eq(expected_version)
@@ -142,9 +142,9 @@ RSpec.describe VersionBoss::Gem::IncrementableVersion do
 
       context 'when the arg pre: true is given' do
         let(:args) { { pre: true } }
-        let(:version) { '1.2.3.pre.3' }
-        let(:expected_version) { described_class.new('1.3.0.pre.1') }
-        it "should increment the minor part and set pre-release part to 'pre.1'" do
+        let(:version) { '1.2.3.pre3' }
+        let(:expected_version) { described_class.new('1.3.0.pre1') }
+        it "should increment the minor part and set pre-release part to 'pre1'" do
           expect(subject).to eq(expected_version)
         end
       end
@@ -152,8 +152,8 @@ RSpec.describe VersionBoss::Gem::IncrementableVersion do
       context 'when the args pre: true, pre_type: "alpha" are given' do
         let(:args) { { pre: true, pre_type: 'alpha' } }
         let(:version) { '1.2.3.pre.3' }
-        let(:expected_version) { described_class.new('1.3.0.alpha.1') }
-        it "should increment the minor part and set pre-release part to 'alpha.1'" do
+        let(:expected_version) { described_class.new('1.3.0.alpha1') }
+        it "should increment the minor part and set pre-release part to 'alpha1'" do
           expect(subject).to eq(expected_version)
         end
       end
@@ -221,7 +221,7 @@ RSpec.describe VersionBoss::Gem::IncrementableVersion do
       context 'when arg pre: true is given' do
         let(:args) { { pre: true } }
         let(:version) { '1.2.3' }
-        let(:expected_version) { described_class.new('1.2.4.pre.1') }
+        let(:expected_version) { described_class.new('1.2.4.pre1') }
         it 'should increment the patch part and set the pre-release part to "pre.1"' do
           expect(subject).to eq(expected_version)
         end
@@ -230,7 +230,7 @@ RSpec.describe VersionBoss::Gem::IncrementableVersion do
       context "when args pre: true, pre_suffix: 'alpha' are given" do
         let(:args) { { pre: true, pre_type: 'alpha' } }
         let(:version) { '1.2.3' }
-        let(:expected_version) { described_class.new('1.2.4.alpha.1') }
+        let(:expected_version) { described_class.new('1.2.4.alpha1') }
         it 'should increment the patch part and set the pre-release part to "alpha.1"' do
           expect(subject).to eq(expected_version)
         end
@@ -249,7 +249,7 @@ RSpec.describe VersionBoss::Gem::IncrementableVersion do
       context 'when the arg pre: true is given' do
         let(:args) { { pre: true } }
         let(:version) { '1.2.3.pre.3' }
-        let(:expected_version) { described_class.new('1.2.4.pre.1') }
+        let(:expected_version) { described_class.new('1.2.4.pre1') }
         it "should increment the patch part and set pre-release part to 'pre.1'" do
           expect(subject).to eq(expected_version)
         end
@@ -258,8 +258,8 @@ RSpec.describe VersionBoss::Gem::IncrementableVersion do
       context 'when the args pre: true, pre_type: "alpha" are given' do
         let(:args) { { pre: true, pre_type: 'alpha' } }
         let(:version) { '1.2.3.pre.3' }
-        let(:expected_version) { described_class.new('1.2.4.alpha.1') }
-        it "should increment the patch part and set pre-release part to 'alpha.1'" do
+        let(:expected_version) { described_class.new('1.2.4.alpha1') }
+        it "should increment the patch part and set pre-release part to 'alpha1'" do
           expect(subject).to eq(expected_version)
         end
       end

--- a/spec/version_boss/gem/version_spec.rb
+++ b/spec/version_boss/gem/version_spec.rb
@@ -47,14 +47,14 @@ RSpec.describe VersionBoss::Gem::Version do
     end
 
     context 'with a version that includes a pre-release part' do
-      let(:version) { '1.2.3.pre.1' }
+      let(:version) { '1.2.3.pre1' }
       it do
         is_expected.to(
           have_attributes(
             major: '1',
             minor: '2',
             patch: '3',
-            pre_release: '.pre.1'
+            pre_release: '.pre1'
           )
         )
       end


### PR DESCRIPTION
Most Ruby gems do not use the period character between the pre-release type and the pre-release number. 