### PR TITLE
Update continuous integration and experimental ruby builds

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,4 +1,4 @@
-name: CI Build
+name: Continuous Integration
 
 on:
   push:
@@ -7,28 +7,28 @@ on:
   pull_request:
     branches: [main]
 
+  workflow_dispatch:
+
+# Supported platforms / Ruby versions:
+#  - Ubuntu: MRI (3.1, 3.2, 3.3), TruffleRuby (24), JRuby (9.4)
+#  - Windows: MRI (3.1), JRuby (9.4)
+
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
+
     runs-on: ${{ matrix.operating-system }}
-    continue-on-error: ${{ matrix.experimental == 'Yes' }}
+    continue-on-error: true
 
     strategy:
+      fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", head, jruby-head]
+        ruby: ["3.1", "3.2", "3.3", "jruby-9.4", "truffleruby-24"]
         operating-system: [ubuntu-latest]
-        experimental: [No]
         include:
-          - ruby: "3.0"
+          - ruby: "3.1"
             operating-system: windows-latest
-          - ruby: head
-            operating-system: ubuntu-latest
-            # If the 'ruby: head' build fails, it is ok to set 'experimental: Yes'
-            # in order to make the workflow continue. Open a GitHub issue about
-            # the failure. Comment out the 'experimental: Yes' line once the
-            # issue is resolved.
-            # experimental: Yes
-          - ruby: jruby-head
+          - ruby: "jruby-9.4"
             operating-system: windows-latest
 
     steps:
@@ -45,10 +45,10 @@ jobs:
         run: bundle exec rake
 
   coverage:
+    name: Report test coverage to CodeClimate
+
     needs: [build]
     runs-on: ubuntu-latest
-
-    name: Report test coverage to CodeClimate
 
     steps:
       - name: Checkout
@@ -60,12 +60,10 @@ jobs:
           ruby-version: 3.1
           bundler-cache: true
 
-      - name: Run tests
-        run: bundle exec rake spec
-
       - name: Report test coverage
-        uses: paambaati/codeclimate-action@v5.0.0
+        uses: paambaati/codeclimate-action@v9
         env:
           CC_TEST_REPORTER_ID: 103c3881b137d757cdf9d9201d89d72184fe2676b2eed08bbe930358b08581de
         with:
+          coverageCommand: bundle exec rake spec
           coverageLocations: ${{github.workspace}}/coverage/lcov/*.lcov:lcov

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -1,0 +1,46 @@
+name: Experimental Ruby Builds
+
+on:
+  push:
+    branches: [main]
+
+  workflow_dispatch:
+
+# Experimental platforms / Ruby versions:
+#  - Ubuntu: MRI (head), TruffleRuby (head), JRuby (head)
+#  - Windows: MRI (head), JRuby (head)
+
+jobs:
+  build:
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
+    
+    runs-on: ${{ matrix.operating-system }}
+    continue-on-error: true
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ruby: head
+            operating-system: ubuntu-latest
+          - ruby: head
+            operating-system: windows-latest
+          - ruby: truffleruby-head
+            operating-system: ubuntu-latest
+          - ruby: jruby-head
+            operating-system: ubuntu-latest
+          - ruby: jruby-head
+            operating-system: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run rake
+        run: bundle exec rake

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
   SuggestExtensions: false
   # RuboCop enforces rules depending on the oldest version of Ruby which
   # your project supports:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 Gemspec/DevelopmentDependencies:
   EnforcedStyle: gemspec

--- a/spec/version_boss/gem/version_file_spec.rb
+++ b/spec/version_boss/gem/version_file_spec.rb
@@ -26,12 +26,21 @@ RSpec.describe VersionBoss::Gem::VersionFile do
     it do
       is_expected.to(
         have_attributes(
-          path: path,
-          content_before: content_before,
-          version: version,
-          content_after: content_after
+          path:,
+          content_before:,
+          version:,
+          content_after:
         )
       )
+    end
+
+    context 'when the version is not an IncrementableVersion' do
+      let(:version_file) { described_class.new(path, content_before, '2.4.0', content_after) }
+      subject { version_file }
+
+      it 'should raise a VersionBoss::Error' do
+        expect { subject }.to raise_error(VersionBoss::Error, 'version must be an IncrementableVersion')
+      end
     end
   end
 
@@ -68,6 +77,15 @@ RSpec.describe VersionBoss::Gem::VersionFile do
       version_file.version = new_version
       actual_content = File.read(path)
       expect(actual_content).to eq(expected_content)
+    end
+
+    context 'when the new version is not an IncrementableVersion' do
+      let(:new_version) { '9.9.9' }
+      it 'should raise a VersionBoss::Error' do
+        expect { version_file.version = new_version }.to(
+          raise_error(VersionBoss::Error, 'new_version must be an IncrementableVersion')
+        )
+      end
     end
   end
 end

--- a/version_boss.gemspec
+++ b/version_boss.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.homepage = 'http://github.com/main-branch/version_boss'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '>= 3.1.0'
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
@@ -35,6 +35,10 @@ Gem::Specification.new do |spec|
   spec.bindir = 'exe'
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+  spec.requirements = [
+    'Platform: Mac, Linux, or Windows',
+    'Ruby: MRI 3.1 or later, TruffleRuby 24 or later, or JRuby 9.4 or later'
+  ]
 
   spec.add_dependency 'thor', '~> 1.3'
 


### PR DESCRIPTION
Update continuous integration and experimental Ruby builds making the following changes:

* Change supported platforms / Ruby versions
  * Continuous integration platforms / Ruby versions:
    * Ubuntu: MRI (3.1, 3.2, 3.3), TruffleRuby (24), JRuby (9.4)
    * Windows: MRI (3.1), JRuby (9.4)
  * Experimental platforms / Ruby versions:
    * Ubuntu: MRI (head), TruffleRuby (head), JRuby (head)
    * Windows: MRI (head), JRuby (head)

* Update continuous integration and experimental ruby builds to use the same workflow for all projects (including possibly renaming the workflow file name and name)

* Update the minimally required Ruby in the project’s gemspec and .rubocop.yml

* Update dependencies to latest

* Auto correct new Rubocop offenses