### PR TITLE
Use latest version of create_github_release

### DIFF
--- a/version_boss.gemspec
+++ b/version_boss.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor', '~> 1.3'
 
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
-  spec.add_development_dependency 'create_github_release', '~> 1.3'
+  spec.add_development_dependency 'create_github_release', '~> 1.5'
   spec.add_development_dependency 'rake', '~> 13.1'
   spec.add_development_dependency 'rspec', '~> 3.12'
   spec.add_development_dependency 'rubocop', '~> 1.59'


### PR DESCRIPTION
Use latest version of create_github_release to make releases of this gem.