### PR TITLE
Integrate SimpleCov::RSpec into the project

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,6 +31,9 @@ jobs:
           - ruby: "jruby-9.4"
             operating-system: windows-latest
 
+    env:
+      JRUBY_OPTS: --debug
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/lib/version_boss/gem/incrementable_version.rb
+++ b/lib/version_boss/gem/incrementable_version.rb
@@ -31,14 +31,7 @@ module VersionBoss
       # @return [Boolean] true if the version string is a valid semver and meets the conditions above
       #
       def valid?
-        super && (
-          pre_release.empty? ||
-          (
-            pre_release_identifiers.size == 2 &&
-            pre_type.is_a?(String) &&
-            pre_number.is_a?(Integer)
-          )
-        )
+        super && (pre_release.empty? || (pre_release_identifiers.size == 2 && pre_number.is_a?(Integer)))
       end
 
       # The default pre-release identifier
@@ -194,9 +187,11 @@ module VersionBoss
       def assert_pre_type_is_valid(pre_type)
         return if self.pre_type <= pre_type
 
+        # :nocov: JRuby coverage does not report this line correctly
         message = 'Cannot increment the pre-release identifier ' \
                   "from '#{self.pre_type}' to '#{pre_type}' " \
                   "because '#{self.pre_type}' is lexically less than '#{pre_type}'"
+        # :nocov:
 
         raise VersionBoss::Error, message
       end

--- a/lib/version_boss/gem/version_file.rb
+++ b/lib/version_boss/gem/version_file.rb
@@ -26,8 +26,9 @@ module VersionBoss
       # @api private
       #
       def initialize(path, content_before, version, content_after)
-        raise VersionBoss::Error, 'version must be an IncrementableVersion' unless
-          version.is_a?(VersionBoss::Gem::IncrementableVersion)
+        unless version.is_a?(VersionBoss::Gem::IncrementableVersion)
+          raise VersionBoss::Error, 'version must be an IncrementableVersion'
+        end
 
         @path = path
         @content_before = content_before
@@ -92,8 +93,9 @@ module VersionBoss
       # @api public
       #
       def version=(new_version)
-        raise VersionBoss::Error, 'new_version must be an IncrementableVersion' unless
-          new_version.is_a?(VersionBoss::Gem::IncrementableVersion)
+        unless new_version.is_a?(VersionBoss::Gem::IncrementableVersion)
+          raise VersionBoss::Error, 'new_version must be an IncrementableVersion'
+        end
 
         @version = version
         File.write(path, content_before + new_version.to_s + content_after)

--- a/lib/version_boss/gem/version_file_sources/base.rb
+++ b/lib/version_boss/gem/version_file_sources/base.rb
@@ -18,7 +18,9 @@ module VersionBoss
         # @return [VersionBoss::Gem::VersionFile, nil] the version file or nil if no version file was found
         #
         def self.find
+          # :nocov: JRuby does not mark the following line as covered
           Dir[glob].filter_map do |path|
+            # :nocov:
             if (match = File.read(path).match(content_regexp))
               version = VersionBoss::Gem::IncrementableVersion.new(match[:version])
               VersionBoss::Gem::VersionFile.new(path, match[:content_before], version, match[:content_after])

--- a/lib/version_boss/gem/version_file_sources/gemspec.rb
+++ b/lib/version_boss/gem/version_file_sources/gemspec.rb
@@ -11,6 +11,8 @@ module VersionBoss
       # @api public
       #
       class Gemspec < Base
+        # :nocov: JRuby does not mark the line with VersionBoss::Gem::REGEXP.source as covered
+
         # The regexp to find the version and surrounding content within the gemspec
         VERSION_REGEXP = /
           \A
@@ -18,10 +20,12 @@ module VersionBoss
               .*
               \.version\s*=\s*(?<quote>['"])
             )
-            (?<version>#{REGEXP.source})
+            (?<version>#{VersionBoss::Gem::REGEXP.source})
             (?<content_after>\k<quote>.*)
           \z
         /xm
+
+        # :nocov:
 
         private
 

--- a/lib/version_boss/gem/version_file_sources/version.rb
+++ b/lib/version_boss/gem/version_file_sources/version.rb
@@ -10,6 +10,8 @@ module VersionBoss
       # @api public
       #
       class Version < Base
+        # :nocov: JRuby does not mark the line with VersionBoss::Gem::REGEXP.source as covered
+
         # The regexp to find the version and surrounding content within the version file
         VERSION_REGEXP = /
           \A
@@ -18,6 +20,8 @@ module VersionBoss
             (?<content_after>\s*)
           \z
         /x
+
+        # :nocov:
 
         private
 

--- a/lib/version_boss/gem/version_file_sources/version_rb.rb
+++ b/lib/version_boss/gem/version_file_sources/version_rb.rb
@@ -10,6 +10,8 @@ module VersionBoss
       # @api public
       #
       class VersionRb < Base
+        # :nocov: JRuby does not mark the line with VersionBoss::Gem::REGEXP.source as covered
+
         # The regexp to find the version and surrounding content within the version.rb file
         VERSION_REGEXP = /
           \A
@@ -21,6 +23,8 @@ module VersionBoss
             (?<content_after>\k<quote>.*)
           \z
         /xm
+
+        # :nocov:
 
         private
 

--- a/lib/version_boss/semver/incrementable_version.rb
+++ b/lib/version_boss/semver/incrementable_version.rb
@@ -27,18 +27,12 @@ module VersionBoss
       #   IncrementableVersion.new('1.2.3-alpha').valid? # => raise VersionBoss::Error
       #   IncrementableVersion.new('1.2.3-alpha.1.2').valid? # => raise VersionBoss::Error
       #   IncrementableVersion.new('1.2.3-alpha.one').valid? # => raise VersionBoss::Error
+      #   IncrementableVersion.new('').valid? # => raise VersionBoss::Error
       #
       # @return [Boolean] true if the version string is a valid semver and meets the conditions above
       #
       def valid?
-        super && (
-          pre_release.empty? ||
-          (
-            pre_release_identifiers.size == 2 &&
-            pre_type.is_a?(String) &&
-            pre_number.is_a?(Integer)
-          )
-        )
+        super && (pre_release.empty? || (pre_release_identifiers.size == 2 && pre_number.is_a?(Integer)))
       end
 
       # The default pre-release identifier
@@ -170,9 +164,11 @@ module VersionBoss
       def assert_pre_type_is_valid(pre_type)
         return if self.pre_type <= pre_type
 
+        # :nocov: JRuby coverage does not report this line correctly
         message = 'Cannot increment the pre-release identifier ' \
                   "from '#{self.pre_type}' to '#{pre_type}' " \
                   "because '#{self.pre_type}' is lexically less than '#{pre_type}'"
+        # :nocov:
 
         raise VersionBoss::Error, message
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -344,113 +344,22 @@ RSpec.shared_examples 'Gem Core Version Incrementer' do |part, from_version, to_
   end
 end
 
-# Setup simplecov
-
+# SimpleCov configuration
+#
 require 'simplecov'
 require 'simplecov-lcov'
-require 'json'
+require 'simplecov-rspec'
 
-SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter, SimpleCov::Formatter::LcovFormatter]
+def ci_build? = ENV.fetch('GITHUB_ACTIONS', 'false') == 'true'
 
-# Return `true` if the environment variable is set to a truthy value
-#
-# @example
-#   env_true?('COV_SHOW_UNCOVERED')
-#
-# @param name [String] the name of the environment variable
-# @return [Boolean]
-#
-def env_true?(name)
-  value = ENV.fetch(name, '').downcase
-  %w[yes on true 1].include?(value)
+if ci_build?
+  SimpleCov.formatters = [
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::LcovFormatter
+  ]
 end
 
-# Return `true` if the environment variable is NOT set to a truthy value
-#
-# @example
-#   env_false?('COV_NO_FAIL')
-#
-# @param name [String] the name of the environment variable
-# @return [Boolean]
-#
-def env_false?(name)
-  !env_true?(name)
-end
-
-# Return `true` if the the test run should fail if the coverage is below the threshold
-#
-# @return [Boolean]
-#
-def fail_on_low_coverage?
-  !(RSpec.configuration.dry_run? || env_true?('COV_NO_FAIL'))
-end
-
-# Return `true` if the the test run should show the lines not covered by tests
-#
-# @return [Boolean]
-#
-def show_lines_not_covered?
-  env_true?('COV_SHOW_UNCOVERED')
-end
-
-# Report if the test coverage was below the configured threshold
-#
-# The threshold is configured by setting the `test_coverage_threshold` variable
-# in this file.
-#
-# Example:
-#
-# ```Ruby
-# test_coverage_threshold = 100
-# ```
-#
-# Coverage below the threshold will cause the rspec run to fail unless the
-# `COV_NO_FAIL` environment variable is set to TRUE.
-#
-# ```Shell
-# COV_NO_FAIL=TRUE rspec
-# ```
-#
-# Example of running the tests in an infinite loop writing failures to `fail.txt`:
-#
-# ```Shell
-# while true; do COV_NO_FAIL=TRUE rspec >> fail.txt; done
-# ````
-#
-# The lines missing coverage will be displayed if the `COV_SHOW_UNCOVERED`
-# environment variable is set to TRUE.
-#
-# ```Shell
-# COV_SHOW_UNCOVERED=TRUE rspec
-# ```
-#
-test_coverage_threshold = 100
-
-SimpleCov.at_exit do
-  SimpleCov.result.format!
-  # rubocop:disable Style/StderrPuts
-  if SimpleCov.result.covered_percent < test_coverage_threshold
-    $stderr.puts
-    $stderr.print 'FAIL: ' if fail_on_low_coverage?
-    $stderr.puts "RSpec Test coverage fell below #{test_coverage_threshold}%"
-
-    if show_lines_not_covered?
-      $stderr.puts "\nThe following lines were not covered by tests:\n"
-      SimpleCov.result.files.each do |source_file| # SimpleCov::SourceFile
-        source_file.missed_lines.each do |line| # SimpleCov::SourceFile::Line
-          $stderr.puts "  .#{source_file.project_filename}:#{line.number}"
-        end
-      end
-    end
-
-    $stderr.puts
-
-    exit 1 if fail_on_low_coverage?
-  end
-  # rubocop:enable Style/StderrPuts
-end
-
-SimpleCov.start
+SimpleCov::RSpec.start(list_uncovered_lines: ci_build?)
 
 # Make sure to require your project AFTER SimpleCov.start
 #

--- a/spec/version_boss/gem/incrementable_version_spec.rb
+++ b/spec/version_boss/gem/incrementable_version_spec.rb
@@ -38,6 +38,13 @@ RSpec.describe VersionBoss::Gem::IncrementableVersion do
         expect { subject }.to raise_error(VersionBoss::Error)
       end
     end
+
+    context 'when the version is an empty string' do
+      let(:version) { '' }
+      it 'is expected to raise an VersionBoss::Error' do
+        expect { subject }.to raise_error(VersionBoss::Error)
+      end
+    end
   end
 
   describe '#next_major' do

--- a/spec/version_boss/gem/version_file_spec.rb
+++ b/spec/version_boss/gem/version_file_spec.rb
@@ -55,6 +55,8 @@ RSpec.describe VersionBoss::Gem::VersionFile do
       end
     ORIGINAL_CONTENT
 
+    # :nocov: JRuby does not mark the #{new_version} as covered
+
     let(:expected_content) { <<~UPDATED_CONTENT }
       # frozen_string_literal: true
 
@@ -62,6 +64,8 @@ RSpec.describe VersionBoss::Gem::VersionFile do
         VERSION = '#{new_version}'
       end
     UPDATED_CONTENT
+
+    # :nocov:
 
     around do |example|
       Dir.mktmpdir do |dir|

--- a/spec/version_boss/semver/incrementable_version_spec.rb
+++ b/spec/version_boss/semver/incrementable_version_spec.rb
@@ -38,6 +38,13 @@ RSpec.describe VersionBoss::Semver::IncrementableVersion do
         expect { subject }.to raise_error(VersionBoss::Error)
       end
     end
+
+    context 'when the version is an empty string' do
+      let(:version) { '' }
+      it 'is expected to raise an VersionBoss::Error' do
+        expect { subject }.to raise_error(VersionBoss::Error)
+      end
+    end
   end
 
   describe '#next_major' do

--- a/version_boss.gemspec
+++ b/version_boss.gemspec
@@ -49,6 +49,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.59'
   spec.add_development_dependency 'simplecov', '~> 0.22'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
+  spec.add_development_dependency 'simplecov-rspec', '~> 0.2'
 
   unless RUBY_PLATFORM == 'java'
     spec.add_development_dependency 'redcarpet', '~> 3.6'


### PR DESCRIPTION
simplecov-rspec is a Ruby gem that integrates SimpleCov with RSpec to ensure your tests meet a minimum coverage threshold. It enhances your test suite by automatically failing tests when coverage falls below a specified threshold and, optionally, listing uncovered lines to help you improve coverage.
