### PR TITLE
Update links in gemspec

### DIFF
--- a/version_boss.gemspec
+++ b/version_boss.gemspec
@@ -14,16 +14,17 @@ Gem::Specification.new do |spec|
     command or the 'VersionBoss::Gem::Version' class.
   DESC
 
-  spec.homepage = 'http://github.com/main-branch/version_boss'
   spec.license = 'MIT'
   spec.required_ruby_version = '>= 3.1.0'
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
+  # Project links
+  spec.homepage = "https://github.com/main-branch/#{spec.name}"
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage
-  spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"
   spec.metadata['documentation_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}"
+  spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
Update homepage, source code, changelog, and documentation links in the gemspec.

Make sure that changelog and documentation links go to the changelog and documenation for the version of the gem the documentation is viewed from.

Source code link should always go to HEAD on the default branch.