### PR TITLE
Add TargetRubyVersion in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,7 @@
 inherit_gem:
   main_branch_shared_rubocop_config: config/rubocop.yml
+
+AllCops:
+  # Pin this project to Ruby 3.1 in case the shared config above is upgraded to 3.2
+  # or later.
+  TargetRubyVersion: 3.1


### PR DESCRIPTION
Need to add the TargetRubyVersion so this project can stay on Ruby 3.1 even if the shared config is updated to 3.2.