### PR TITLE
chore: update create_github_release dependency

### DIFF
--- a/version_boss.gemspec
+++ b/version_boss.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor', '~> 1.3'
 
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
-  spec.add_development_dependency 'create_github_release', '~> 1.5'
+  spec.add_development_dependency 'create_github_release', '~> 2.1'
   spec.add_development_dependency 'main_branch_shared_rubocop_config', '~> 0.1'
   spec.add_development_dependency 'rake', '~> 13.1'
   spec.add_development_dependency 'rspec', '~> 3.12'


### PR DESCRIPTION
Since conventional commits are now enforced,
use a version of create_github_release that
creates a valid conventional commit.