### PR TITLE
Remove Code Climate integration

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,27 +48,3 @@ jobs:
 
       - name: Run rake
         run: bundle exec rake
-
-  coverage:
-    name: Report test coverage to CodeClimate
-
-    needs: [build]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Initialize Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 3.1
-          bundler-cache: true
-
-      - name: Report test coverage
-        uses: paambaati/codeclimate-action@v9
-        env:
-          CC_TEST_REPORTER_ID: 103c3881b137d757cdf9d9201d89d72184fe2676b2eed08bbe930358b08581de
-        with:
-          coverageCommand: bundle exec rake spec
-          coverageLocations: ${{github.workspace}}/coverage/lcov/*.lcov:lcov

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 [![Documentation](https://img.shields.io/badge/Documentation-Latest-green)](https://rubydoc.info/gems/version_boss/)
 [![Change Log](https://img.shields.io/badge/CHANGELOG-Latest-green)](https://rubydoc.info/gems/version_boss/file/CHANGELOG.md)
 [![Build Status](https://github.com/main-branch/version_boss/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/main-branch/version_boss/actions/workflows/continuous-integration.yml)
-[![Maintainability](https://api.codeclimate.com/v1/badges/44a42ed085fe162e5dff/maintainability)](https://codeclimate.com/github/main-branch/version_boss/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/44a42ed085fe162e5dff/test_coverage)](https://codeclimate.com/github/main-branch/version_boss/test_coverage)
 [![Conventional
 Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
 [![Slack](https://img.shields.io/badge/slack-main--branch/version__boss-yellow.svg?logo=slack)](https://main-branch.slack.com/archives/C07MCMDBJLX)
@@ -47,15 +45,15 @@ gem-version-boss help [COMMAND]
 
 * [Installation](#installation)
 * [Command Line](#command-line)
-  * [Usage](#usage)
-  * [Examples](#examples)
+    * [Usage](#usage)
+    * [Examples](#examples)
 * [Library Usage](#library-usage)
-  * [VersionBoss::Gem classes](#versionbossgem-classes)
-  * [VersionBoss::Semver classes](#versionbosssemver-classes)
+    * [VersionBoss::Gem classes](#versionbossgem-classes)
+    * [VersionBoss::Semver classes](#versionbosssemver-classes)
 * [Development](#development)
 * [Contributing](#contributing)
-  * [Commit message guidelines](#commit-message-guidelines)
-  * [Pull request guidelines](#pull-request-guidelines)
+    * [Commit message guidelines](#commit-message-guidelines)
+    * [Pull request guidelines](#pull-request-guidelines)
 * [License](#license)
 
 ## Installation


### PR DESCRIPTION
Eliminate Code Climate integration from the build process and associated badges in the documentation.